### PR TITLE
Define entity relationships

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -19,7 +19,7 @@ import { TypeOrmModule } from '@nestjs/typeorm';
         username: configService.get<string>('DB_USER'),
         password: configService.get<string>('DB_PASSWORD'),
         database: configService.get<string>('DB_NAME'),
-        autoLoadEntities: true, // Automatically loads entity files
+        entities: [__dirname + '/**/*.entity{.ts}'], //loads all entities from the entities folder with the .entity.ts extension
         synchronize: true, // ⚠️ Auto-sync schema (disable in production)
       }),
     }),

--- a/src/entities/category.entity.ts
+++ b/src/entities/category.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import { Course } from './course.entity';
+
+@Entity('categories')
+export class Category {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    name: string;
+
+    @OneToMany(() => Course, (course) => course.category, {
+        cascade: true,
+    })
+    courses: Course[];
+}

--- a/src/entities/certificate.entity.ts
+++ b/src/entities/certificate.entity.ts
@@ -1,0 +1,32 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, Index } from 'typeorm';
+import { User } from './user.entity';
+import { Course } from './course.entity';
+
+@Entity('certificates')
+export class Certificate {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    title: string;
+
+    @Column({ nullable: true })
+    description: string;
+
+    @Column()
+    issueDate: Date;
+
+    @ManyToOne(() => User, (user) => user.userProgress, {
+        eager: true,
+        onDelete: 'CASCADE',
+    })
+    @Index()
+    user: User;
+
+    @ManyToOne(() => Course, (course) => course.certificates, {
+        eager: true,
+        onDelete: 'CASCADE',
+    })
+    @Index()
+    course: Course;
+}

--- a/src/entities/course-review.entity.ts
+++ b/src/entities/course-review.entity.ts
@@ -1,0 +1,32 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, Index } from 'typeorm';
+import { User } from './user.entity';
+import { Course } from './course.entity';
+
+@Entity('course_reviews')
+export class CourseReview {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column({ type: 'text' })
+    reviewText: string;
+
+    @Column({ type: 'int', default: 0 })
+    rating: number; // Rating out of 5
+
+    @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+    createdAt: Date;
+
+    @ManyToOne(() => User, (user) => user.courseReviews, {
+        eager: true,
+        onDelete: 'CASCADE',
+    })
+    @Index()
+    user: User;
+
+    @ManyToOne(() => Course, (course) => course.reviews, {
+        eager: true,
+        onDelete: 'CASCADE',
+    })
+    @Index()
+    course: Course;
+}

--- a/src/entities/course.entity.ts
+++ b/src/entities/course.entity.ts
@@ -1,0 +1,76 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany, ManyToOne, ManyToMany, JoinTable, Index } from 'typeorm';
+import { Module } from './module.entity';
+import { Certificate } from './certificate.entity';
+import { CourseReview } from './course-review.entity';
+import { Payment } from './payment.entity';
+import { UserProgress } from './user-progress.entity';
+import { Category } from './category.entity';
+import { User } from './user.entity';
+import { Tag } from './tag.entity';
+
+
+@Entity('courses')
+export class Course {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    title: string;
+
+    @Column({ nullable: true })
+    description: string;
+
+    @Column()
+    price: number;
+
+    @ManyToOne(() => Category, (category) => category.courses, {
+        eager: true,
+        onDelete: 'SET NULL',
+    })
+    @Index()
+    category: Category;
+
+    @ManyToOne(() => User, (user) => user.instructedCourses, {
+        eager: true,
+        onDelete: 'SET NULL',
+    })
+    @Index()
+    instructor: User;
+
+    @OneToMany(() => Module, (module) => module.course, {
+        cascade: true,
+    })
+    modules: Module[];
+
+    @OneToMany(() => Certificate, (certificate) => certificate.course, {
+        cascade: true,
+    })
+    certificates: Certificate[];
+
+    @OneToMany(() => CourseReview, (courseReview) => courseReview.course, {
+        cascade: true,
+    })
+    reviews: CourseReview[];
+
+    @OneToMany(() => Payment, (payment) => payment.course, {
+        cascade: true,
+    })
+    payments: Payment[];
+
+    @OneToMany(() => UserProgress, (userProgress) => userProgress.course, {
+        cascade: true,
+    })
+    userProgress: UserProgress[];
+
+    @ManyToMany(() => Tag, (tag) => tag.courses, {
+        cascade: true,
+    })
+    @JoinTable()
+    tags: Tag[];
+
+    @ManyToMany(() => User, (user) => user.enrolledCourses, {
+        cascade: ['insert', 'update']
+    })
+    @JoinTable()
+    enrolledUsers: User[];
+}

--- a/src/entities/email-verification-token.entity.ts
+++ b/src/entities/email-verification-token.entity.ts
@@ -1,0 +1,24 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, Index } from 'typeorm';
+import { User } from './user.entity';
+
+@Entity('email_verification_tokens')
+export class EmailVerificationToken {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    token: string;
+
+    @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+    createdAt: Date;
+
+    @Column({ type: 'timestamp', nullable: true })
+    expiresAt: Date;
+
+    @ManyToOne(() => User, (user) => user.emailVerificationTokens, {
+        eager: true,
+        onDelete: 'CASCADE',
+    })
+    @Index()
+    user: User;
+}

--- a/src/entities/forum-categories.entity.ts
+++ b/src/entities/forum-categories.entity.ts
@@ -1,0 +1,16 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany } from 'typeorm';
+import { ForumTopic } from './forum-topics.entity';
+
+@Entity('forum_categories')
+export class ForumCategory {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    name: string;
+
+    @OneToMany(() => ForumTopic, (forumTopic) => forumTopic.category, {
+        cascade: true,
+    })
+    topics: ForumTopic[];
+}

--- a/src/entities/forum-comments.entity.ts
+++ b/src/entities/forum-comments.entity.ts
@@ -1,0 +1,26 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, Index } from 'typeorm';
+import { ForumPost } from './forum-post.entity';
+import { User } from './user.entity';
+
+@Entity('forum_comments')
+export class ForumComment {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    content: string;
+
+    @ManyToOne(() => ForumPost, (forumPost) => forumPost.comments, {
+        eager: true,
+        onDelete: 'CASCADE',
+    })
+    @Index()
+    post: ForumPost;
+
+    @ManyToOne(() => User, (user) => user.forumComments, {
+        eager: true,
+        onDelete: 'SET NULL',
+    })
+    @Index()
+    author: User;
+}

--- a/src/entities/forum-post.entity.ts
+++ b/src/entities/forum-post.entity.ts
@@ -1,0 +1,33 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany, ManyToOne, Index } from 'typeorm';
+import { ForumComment } from './forum-comments.entity';
+import { ForumTopic } from './forum-topics.entity';
+import { User } from './user.entity';
+
+
+@Entity('forum_posts')
+export class ForumPost {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    content: string;
+
+    @ManyToOne(() => ForumTopic, (forumTopic) => forumTopic.posts, {
+        eager: true,
+        onDelete: 'CASCADE',
+    })
+    @Index()
+    topic: ForumTopic;
+
+    @ManyToOne(() => User, (user) => user.forumPosts, {
+        eager: true,
+        onDelete: 'SET NULL',
+    })
+    @Index()
+    author: User;
+
+    @OneToMany(() => ForumComment, (forumComment) => forumComment.post, {
+        cascade: true,
+    })
+    comments: ForumComment[];
+}

--- a/src/entities/forum-topics.entity.ts
+++ b/src/entities/forum-topics.entity.ts
@@ -1,0 +1,24 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany, ManyToOne, Index } from 'typeorm';
+import { ForumCategory } from './forum-categories.entity';
+import { ForumPost } from './forum-post.entity';
+
+@Entity('forum_topics')
+export class ForumTopic {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    title: string;
+
+    @ManyToOne(() => ForumCategory, (forumCategory) => forumCategory.topics, {
+        eager: true,
+        onDelete: 'CASCADE',
+    })
+    @Index()
+    category: ForumCategory;
+
+    @OneToMany(() => ForumPost, (forumPost) => forumPost.topic, {
+        cascade: true,
+    })
+    posts: ForumPost[];
+}

--- a/src/entities/lesson.entity.ts
+++ b/src/entities/lesson.entity.ts
@@ -1,0 +1,30 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany, Index } from 'typeorm';
+import { Module } from './module.entity';
+import { UserProgress } from './user-progress.entity';
+
+@Entity('lessons')
+export class Lesson {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    title: string;
+
+    @Column({ nullable: true })
+    description: string;
+
+    @Column()
+    duration: number; // Duration in minutes
+
+    @ManyToOne(() => Module, (module) => module.lessons, {
+        eager: true,
+        onDelete: 'CASCADE',
+    })
+    @Index()
+    module: Module;
+
+    @OneToMany(() => UserProgress, (userProgress) => userProgress.lesson, {
+        cascade: true,
+    })
+    userProgress: UserProgress[];
+}

--- a/src/entities/module.entity.ts
+++ b/src/entities/module.entity.ts
@@ -1,0 +1,27 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany, Index } from 'typeorm';
+import { Course } from './course.entity';
+import { Lesson } from './lesson.entity';
+
+@Entity('modules')
+export class Module {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    title: string;
+
+    @Column({ nullable: true })
+    description: string;
+
+    @ManyToOne(() => Course, (course) => course.modules, {
+        eager: true,
+        onDelete: 'CASCADE',
+    })
+    @Index()
+    course: Course;
+
+    @OneToMany(() => Lesson, (lesson) => lesson.module, {
+        cascade: true,
+    })
+    lessons: Lesson[];
+}

--- a/src/entities/notification.entity.ts
+++ b/src/entities/notification.entity.ts
@@ -1,0 +1,27 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, Index } from 'typeorm';
+import { User } from './user.entity';
+
+@Entity('notifications')
+export class Notification {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    title: string;
+
+    @Column()
+    message: string;
+
+    @Column({ default: false })
+    isRead: boolean;
+
+    @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+    createdAt: Date;
+
+    @ManyToOne(() => User, (user) => user.notifications, {
+        eager: true,
+        onDelete: 'CASCADE',
+    })
+    @Index()
+    user: User;
+}

--- a/src/entities/password-reset-token.entity.ts
+++ b/src/entities/password-reset-token.entity.ts
@@ -1,0 +1,24 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, Index } from 'typeorm';
+import { User } from './user.entity';
+
+@Entity('password_reset_tokens')
+export class PasswordResetToken {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    token: string;
+
+    @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+    createdAt: Date;
+
+    @Column({ type: 'timestamp', nullable: true })
+    expiresAt: Date;
+
+    @ManyToOne(() => User, (user) => user.passwordResetTokens, {
+        eager: true,
+        onDelete: 'CASCADE',
+    })
+    @Index()
+    user: User;
+}

--- a/src/entities/payment.entity.ts
+++ b/src/entities/payment.entity.ts
@@ -1,0 +1,32 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, Index } from 'typeorm';
+import { User } from './user.entity';
+import { Course } from './course.entity';
+
+@Entity('payments')
+export class Payment {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    amount: number;
+
+    @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+    paymentDate: Date;
+
+    @Column({ nullable: true })
+    paymentMethod: string;
+
+    @ManyToOne(() => User, (user) => user.walletInfo, {
+        eager: true,
+        onDelete: 'SET NULL',
+    })
+    @Index()
+    user: User;
+
+    @ManyToOne(() => Course, (course) => course.payments, {
+        eager: true,
+        onDelete: 'CASCADE',
+    })
+    @Index()
+    course: Course;
+}

--- a/src/entities/refresh-token.entity.ts
+++ b/src/entities/refresh-token.entity.ts
@@ -1,0 +1,24 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, Index } from 'typeorm';
+import { User } from './user.entity';
+
+@Entity('refresh_tokens')
+export class RefreshToken {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    token: string;
+
+    @Column({ type: 'timestamp', default: () => 'CURRENT_TIMESTAMP' })
+    createdAt: Date;
+
+    @Column({ type: 'timestamp', nullable: true })
+    expiresAt: Date;
+
+    @ManyToOne(() => User, (user) => user.refreshTokens, {
+        eager: true,
+        onDelete: 'CASCADE',
+    })
+    @Index()
+    user: User;
+}

--- a/src/entities/tag.entity.ts
+++ b/src/entities/tag.entity.ts
@@ -1,0 +1,14 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToMany } from 'typeorm';
+import { Course } from './course.entity';
+
+@Entity('tags')
+export class Tag {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    name: string;
+
+    @ManyToMany(() => Course, (course) => course.tags)
+    courses: Course[];
+}

--- a/src/entities/user-progress.entity.ts
+++ b/src/entities/user-progress.entity.ts
@@ -1,0 +1,37 @@
+import { Entity, PrimaryGeneratedColumn, ManyToOne, Column, Index } from 'typeorm';
+import { User } from './user.entity';
+import { Course } from './course.entity';
+import { Lesson } from './lesson.entity';
+
+@Entity('user_progress')
+export class UserProgress {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @ManyToOne(() => User, (user) => user.userProgress, {
+        eager: true,
+        onDelete: 'CASCADE',
+    })
+    @Index()
+    user: User;
+
+    @ManyToOne(() => Course, (course) => course.userProgress, {
+        eager: true,
+        onDelete: 'CASCADE',
+    })
+    @Index()
+    course: Course;
+
+    @ManyToOne(() => Lesson, (lesson) => lesson.userProgress, {
+        eager: true,
+        onDelete: 'CASCADE',
+    })
+    @Index()
+    lesson: Lesson;
+
+    @Column({ type: 'float', default: 0 })
+    progressPercentage: number; // Progress percentage (0-100)
+
+    @Column({ type: 'boolean', default: false })
+    completed: boolean; // Indicates if the lesson is completed
+}

--- a/src/entities/user.entity.ts
+++ b/src/entities/user.entity.ts
@@ -1,0 +1,87 @@
+import { Entity, PrimaryGeneratedColumn, Column, OneToMany, ManyToMany, JoinTable } from 'typeorm';
+import { Course } from './course.entity';
+import { UserProgress } from './user-progress.entity';
+import { WalletInfo } from './wallet-info.entity';
+import { RefreshToken } from './refresh-token.entity';
+import { EmailVerificationToken } from './email-verification-token.entity';
+import { PasswordResetToken } from './password-reset-token.entity';
+import { Notification } from './notification.entity';
+import { CourseReview } from './course-review.entity';
+import { ForumPost } from './forum-post.entity';
+import { ForumComment } from './forum-comments.entity';
+
+@Entity('users')
+export class User {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column({ unique: true })
+    email: string;
+
+    @Column()
+    password: string;
+
+    @Column()
+    firstName: string;
+
+    @Column()
+    lastName: string;
+
+    @Column({ default: true })
+    isActive: boolean;
+
+    @OneToMany(() => UserProgress, (userProgress) => userProgress.user, {
+        cascade: true,
+    })
+    userProgress: UserProgress[];
+
+    @OneToMany(() => WalletInfo, (walletInfo) => walletInfo.user, {
+        cascade: true,
+    })
+    walletInfo: WalletInfo[];
+
+    @OneToMany(() => RefreshToken, (refreshToken) => refreshToken.user, {
+        cascade: true,
+    })
+    refreshTokens: RefreshToken[];
+
+    @OneToMany(
+        () => EmailVerificationToken,
+        (emailVerificationToken) => emailVerificationToken.user,
+        { cascade: true },
+    )
+    emailVerificationTokens: EmailVerificationToken[];
+
+    @OneToMany(
+        () => PasswordResetToken,
+        (passwordResetToken) => passwordResetToken.user,
+        { cascade: true },
+    )
+    passwordResetTokens: PasswordResetToken[];
+
+    @OneToMany(() => Notification, (notification) => notification.user, {
+        cascade: true,
+    })
+    notifications: Notification[];
+
+    @OneToMany(() => CourseReview, (courseReview) => courseReview.user, {
+        cascade: true,
+    })
+    courseReviews: CourseReview[];
+
+    @OneToMany(() => ForumPost, (forumPost) => forumPost.author, {
+        cascade: true,
+    })
+    forumPosts: ForumPost[];
+
+    @OneToMany(() => ForumComment, (forumComment) => forumComment.author, {
+        cascade: true,
+    })
+    forumComments: ForumComment[];
+
+    @OneToMany(() => Course, (course) => course.instructor)
+    instructedCourses: Course[];
+
+    @ManyToMany(() => Course, (course) => course.enrolledUsers)
+    enrolledCourses: Course[];
+}

--- a/src/entities/wallet-info.entity.ts
+++ b/src/entities/wallet-info.entity.ts
@@ -1,0 +1,21 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, Index } from 'typeorm';
+import { User } from './user.entity';
+
+@Entity('wallet_info')
+export class WalletInfo {
+    @PrimaryGeneratedColumn('uuid')
+    id: string;
+
+    @Column()
+    walletAddress: string;
+
+    @Column({ nullable: true })
+    balance: number;
+
+    @ManyToOne(() => User, (user) => user.walletInfo, {
+        eager: true,
+        onDelete: 'CASCADE',
+    })
+    @Index()
+    user: User;
+}


### PR DESCRIPTION
This PR implements the inter-entity relationships across modules following the provided instructions. The relationships are defined using TypeORM decorators, ensuring proper cascading rules, foreign key indexing, and optimized eager/lazy loading strategies.

Additionally, a modification was made in app.module.ts to dynamically load all entities, improving maintainability and scalability.

Key Changes
Entity Relationships
User Relationships:

One-to-Many: User → UserProgress, WalletInfo, RefreshToken, EmailVerificationToken, PasswordResetToken, Notification, CourseReview, ForumPost, ForumComment
Many-to-Many: User ↔ Course (enrollments)
Course Relationships:

One-to-Many: Course → Module, Certificate, CourseReview, Payment, UserProgress
Many-to-One: Course → Category, Instructor (User)
Many-to-Many: Course ↔ Tag (via a junction table)
Module Relationships:

One-to-Many: Module → Lesson
Many-to-One: Module → Course
Lesson Relationships:

One-to-Many: Lesson → UserProgress
Many-to-One: Lesson → Module
Forum Relationships:

One-to-Many: ForumCategory → ForumTopic, ForumTopic → ForumPost, ForumPost → ForumComment
Many-to-One: ForumTopic → ForumCategory, ForumPost → ForumTopic, ForumPost → User (author), ForumComment → ForumPost, ForumComment → User (author)
Other Relationships:

Certificate, Payment, Notification, and Auth Tokens have been defined with appropriate Many-to-One or One-to-Many associations with User and Course entities.

Modification in app.module.ts:
- Updated the entities configuration in TypeOrmModule to dynamically load all entities from the entities folder using a pattern-based approach.

Acceptance Criteria:
✔ All relationships are correctly defined using TypeORM decorators.
✔ Foreign key indexes are created for efficient database operations.
✔ Eager/lazy loading strategies are implemented and documented.

Testing:
- Verified that all entities load correctly into the database schema using synchronize: true.

![ERD](https://github.com/user-attachments/assets/5f915a54-570f-4cc2-8e4b-bc4a17fb189e)


I’m open to any feedback, corrections, or modifications as needed.