### PR TITLE
implemented feature hardning k8s

### DIFF
--- a/src/k8s/deployment.yaml
+++ b/src/k8s/deployment.yaml
@@ -33,6 +33,8 @@ spec:
         runAsNonRoot: true
         runAsUser: 1000
         fsGroup: 2000
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: api
         image: analytics-platform/api:latest
@@ -89,6 +91,14 @@ spec:
           limits:
             memory: "512Mi"
             cpu: "500m"
+        securityContext:
+          allowPrivilegeEscalation: false
+          runAsNonRoot: true
+          runAsUser: 1000
+          readOnlyRootFilesystem: true
+          capabilities:
+            drop:
+              - ALL
         livenessProbe:
           httpGet:
             path: /health
@@ -118,10 +128,18 @@ spec:
           mountPath: /tmp
         - name: logs
           mountPath: /app/logs
+        - name: cache
+          mountPath: /app/.npm
+        - name: node-modules-cache
+          mountPath: /app/node_modules/.cache
       volumes:
       - name: tmp
         emptyDir: {}
       - name: logs
+        emptyDir: {}
+      - name: cache
+        emptyDir: {}
+      - name: node-modules-cache
         emptyDir: {}
       nodeSelector:
         kubernetes.io/os: linux

--- a/src/k8s/network-policy.yaml
+++ b/src/k8s/network-policy.yaml
@@ -1,8 +1,11 @@
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: analytics-platform-network-policy
+  name: analytics-platform-api-default-deny
   namespace: analytics-platform
+  labels:
+    app: analytics-platform-api
+    component: backend
 spec:
   podSelector:
     matchLabels:
@@ -10,17 +13,40 @@ spec:
   policyTypes:
   - Ingress
   - Egress
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: analytics-platform-api-allow-ingress
+  namespace: analytics-platform
+  labels:
+    app: analytics-platform-api
+    component: backend
+spec:
+  podSelector:
+    matchLabels:
+      app: analytics-platform-api
+  policyTypes:
+  - Ingress
   ingress:
+  # Allow from ingress controller (nginx)
   - from:
     - namespaceSelector:
         matchLabels:
           name: ingress-nginx
+    ports:
+    - protocol: TCP
+      port: 3000
+  # Allow from pods within same namespace (inter-service communication)
+  - from:
     - podSelector:
         matchLabels:
           app: analytics-platform-api
     ports:
     - protocol: TCP
       port: 3000
+  # Allow Prometheus metrics scraping
   - from:
     - namespaceSelector:
         matchLabels:
@@ -28,7 +54,37 @@ spec:
     ports:
     - protocol: TCP
       port: 9090
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: analytics-platform-api-allow-egress
+  namespace: analytics-platform
+  labels:
+    app: analytics-platform-api
+    component: backend
+spec:
+  podSelector:
+    matchLabels:
+      app: analytics-platform-api
+  policyTypes:
+  - Egress
   egress:
+  # Allow DNS resolution (critical for service discovery)
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53
+  # Allow connection to Redis within namespace
   - to:
     - podSelector:
         matchLabels:
@@ -36,22 +92,52 @@ spec:
     ports:
     - protocol: TCP
       port: 6379
-  - to: []
+  # Allow connection to PostgreSQL/Database (any namespace)
+  - to:
+    - namespaceSelector: {}
     ports:
     - protocol: TCP
       port: 5432
+  # Allow HTTPS for external API calls
+  - to:
+    - namespaceSelector: {}
+    ports:
     - protocol: TCP
       port: 443
+  # Allow HTTP for external API calls (remove if not needed)
+  - to:
+    - namespaceSelector: {}
+    ports:
     - protocol: TCP
       port: 80
-    - protocol: UDP
-      port: 53
+
+---
+# Redis Network Policy - Restrict ingress to authorized pods only
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redis-default-deny
+  namespace: analytics-platform
+  labels:
+    app: redis
+    component: cache
+spec:
+  podSelector:
+    matchLabels:
+      app: redis
+  policyTypes:
+  - Ingress
+  - Egress
+
 ---
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: redis-network-policy
+  name: redis-allow-ingress
   namespace: analytics-platform
+  labels:
+    app: redis
+    component: cache
 spec:
   podSelector:
     matchLabels:
@@ -59,13 +145,49 @@ spec:
   policyTypes:
   - Ingress
   ingress:
+  # Only allow from API pods
   - from:
     - podSelector:
         matchLabels:
           app: analytics-platform-api
+    ports:
+    - protocol: TCP
+      port: 6379
+  # Only allow from worker pods
+  - from:
     - podSelector:
         matchLabels:
           app: analytics-platform-worker
     ports:
     - protocol: TCP
       port: 6379
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: redis-allow-egress
+  namespace: analytics-platform
+  labels:
+    app: redis
+    component: cache
+spec:
+  podSelector:
+    matchLabels:
+      app: redis
+  policyTypes:
+  - Egress
+  egress:
+  # Allow DNS resolution
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          name: kube-system
+      podSelector:
+        matchLabels:
+          k8s-app: kube-dns
+    ports:
+    - protocol: UDP
+      port: 53
+    - protocol: TCP
+      port: 53

--- a/src/k8s/pdb.yaml
+++ b/src/k8s/pdb.yaml
@@ -1,21 +1,33 @@
+# PodDisruptionBudget for analytics-platform-api
+# With 3 replicas, keeping 2 available ensures true HA during disruptions
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: analytics-platform-api-pdb
   namespace: analytics-platform
+  labels:
+    app: analytics-platform-api
+    component: backend
 spec:
-  minAvailable: 1
+  minAvailable: 2  # Ensures 2 pods always serving traffic (out of 3 replicas)
   selector:
     matchLabels:
       app: analytics-platform-api
+  unhealthyPodEvictionPolicy: IfHealthyBudget  # Allows stuck pods to be evicted
+
 ---
+# PodDisruptionBudget for analytics-platform-worker
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: analytics-platform-worker-pdb
   namespace: analytics-platform
+  labels:
+    app: analytics-platform-worker
+    component: worker
 spec:
   minAvailable: 1
   selector:
     matchLabels:
       app: analytics-platform-worker
+  unhealthyPodEvictionPolicy: IfHealthyBudget


### PR DESCRIPTION
closes #378 

Network Policy Enhancements
Key Changes:

Default-Deny Approach: Added separate default-deny policies first, then explicit allow rules

More secure: explicitly denies everything, then allows only what's needed
Prevents accidental exposure


DNS Resolution Fixed: Added proper DNS egress rules

Your original had to: [] which was too permissive
Now explicitly allows DNS to kube-system CoreDNS


Separated Concerns: Split into multiple focused policies

Easier to manage and troubleshoot
Better visibility into what's allowed


Added Redis Egress: Redis now has proper egress rules (was missing)
Better Labels: Added component labels for better organization

What Each Policy Does:
analytics-platform-api:

Default deny all → then allow specific ingress/egress
Ingress from: nginx ingress, same namespace pods, monitoring
 Egress to: DNS, Redis, PostgreSQL, external HTTPS/HTTP

redis:

 Default deny all → then allow specific ingress/egress
 Ingress only from: API and Worker pods
 Egress to: DNS only

 PDB Enhancements
Key Changes:

Increased minAvailable for API: Changed from 1 to 2

With 3 replicas, keeping 2 available is better for HA
Prevents complete outages during rolling updates or node drains


Added unhealthyPodEvictionPolicy: Set to IfHealthyBudget

Allows eviction of unhealthy pods even if budget is violated
Prevents stuck deployments with crashlooping pods


Better Labels: Added component labels