### PR TITLE
feat(elective-course): Build Elective Courses CRUD API + Integration Tests

### DIFF
--- a/src/elective-course/elective-course.controller.spec.ts
+++ b/src/elective-course/elective-course.controller.spec.ts
@@ -1,0 +1,102 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import * as request from 'supertest';
+import { ElectiveCourseController } from './elective-course.controller';
+import { ElectiveCourseService } from './elective-course.service';
+import { ElectiveCourse } from './entities/elective-course.entity';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+
+describe('ElectiveCourseController (integration)', () => {
+  let app: INestApplication;
+
+  const mockAuthGuard = {
+    canActivate: () => true,
+  };
+
+  beforeAll(async () => {
+    const moduleFixture: TestingModule = await Test.createTestingModule({
+      imports: [
+        TypeOrmModule.forRoot({
+          type: 'sqlite',
+          database: ':memory:',
+          entities: [ElectiveCourse],
+          synchronize: true,
+        }),
+        TypeOrmModule.forFeature([ElectiveCourse]),
+      ],
+      controllers: [ElectiveCourseController],
+      providers: [ElectiveCourseService],
+    })
+      .overrideGuard(JwtAuthGuard)
+      .useValue(mockAuthGuard)
+      .compile();
+
+    app = moduleFixture.createNestApplication();
+    app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+    await app.init();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('POST /elective-courses -> create course (protected)', async () => {
+    const payload = { title: 'Test Course', description: 'desc', creditHours: 3 };
+    const res = await request(app.getHttpServer())
+      .post('/elective-courses')
+      .send(payload)
+      .expect(201);
+
+    expect(res.body).toHaveProperty('status', 'success');
+    expect(res.body.data).toHaveProperty('id');
+    expect(res.body.data.title).toBe('Test Course');
+  });
+
+  it('GET /elective-courses -> list courses (public)', async () => {
+    const res = await request(app.getHttpServer()).get('/elective-courses').expect(200);
+    expect(res.body).toHaveProperty('status', 'success');
+    expect(Array.isArray(res.body.data)).toBe(true);
+  });
+
+  it('GET /elective-courses/:id -> get single course (public)', async () => {
+    // create first
+    const create = await request(app.getHttpServer())
+      .post('/elective-courses')
+      .send({ title: 'Single', creditHours: 2 })
+      .expect(201);
+
+    const id = create.body.data.id;
+    const res = await request(app.getHttpServer()).get(`/elective-courses/${id}`).expect(200);
+    expect(res.body.data.id).toBe(id);
+    expect(res.body.data.title).toBe('Single');
+  });
+
+  it('PATCH /elective-courses/:id -> update course (protected)', async () => {
+    const create = await request(app.getHttpServer())
+      .post('/elective-courses')
+      .send({ title: 'ToUpdate', creditHours: 4 })
+      .expect(201);
+    const id = create.body.data.id;
+
+    const res = await request(app.getHttpServer())
+      .patch(`/elective-courses/${id}`)
+      .send({ title: 'Updated' })
+      .expect(200);
+
+    expect(res.body.data.title).toBe('Updated');
+  });
+
+  it('DELETE /elective-courses/:id -> delete course (protected)', async () => {
+    const create = await request(app.getHttpServer())
+      .post('/elective-courses')
+      .send({ title: 'ToDelete', creditHours: 1 })
+      .expect(201);
+    const id = create.body.data.id;
+
+    await request(app.getHttpServer()).delete(`/elective-courses/${id}`).expect(200);
+
+    // confirm deleted
+    await request(app.getHttpServer()).get(`/elective-courses/${id}`).expect(404);
+  });
+});

--- a/src/elective-course/elective-course.controller.ts
+++ b/src/elective-course/elective-course.controller.ts
@@ -1,0 +1,72 @@
+import {
+  Controller,
+  Post,
+  Get,
+  Patch,
+  Delete,
+  Param,
+  Body,
+  UseGuards,
+  Query,
+  NotFoundException,
+} from '@nestjs/common';
+import { ElectiveCourseService } from './elective-course.service';
+import { CreateElectiveCourseDto } from './dto/create-elective-course.dto';
+import { UpdateElectiveCourseDto } from './dto/update-elective-course.dto';
+import { JwtAuthGuard } from 'src/auth/guards/jwt-auth.guard';
+import { Public } from 'src/auth/decorators/public.decorator';
+
+// Standardized response helper
+function standardResponse(data: any, message = 'OK') {
+  return { status: 'success', message, data };
+}
+
+@Controller('elective-courses')
+export class ElectiveCourseController {
+  constructor(private readonly service: ElectiveCourseService) {}
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  async create(@Body() dto: CreateElectiveCourseDto) {
+    const created = await this.service.createCourse(dto);
+    return standardResponse(created, 'Elective course created');
+  }
+
+  @Get()
+  @Public()
+  async findAll(@Query('category') category?: string, @Query('isActive') isActive?: string) {
+    // Service currently supports simple fetch; apply basic filter on returned list
+    const all = await this.service.getAllCourses();
+    let filtered = all;
+    if (category) {
+      filtered = filtered.filter((c) => (c as any).category === category);
+    }
+    if (isActive !== undefined) {
+      const flag = isActive === 'true' || isActive === '1';
+      filtered = filtered.filter((c) => ((c as any).isActive ?? true) === flag);
+    }
+    return standardResponse(filtered, 'Elective courses retrieved');
+  }
+
+  @Get(':id')
+  @Public()
+  async findOne(@Param('id') id: string) {
+    const found = await this.service.getCourseById(id);
+    if (!found) throw new NotFoundException('Elective course not found');
+    return standardResponse(found, 'Elective course retrieved');
+  }
+
+  @Patch(':id')
+  @UseGuards(JwtAuthGuard)
+  async update(@Param('id') id: string, @Body() dto: UpdateElectiveCourseDto) {
+    const updated = await this.service.updateCourse(id, dto);
+    return standardResponse(updated, 'Elective course updated');
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard)
+  async remove(@Param('id') id: string) {
+    await this.service.deleteCourse(id);
+    return standardResponse(null, 'Elective course deleted');
+  }
+}


### PR DESCRIPTION

### Summary

This PR introduces a NestJS controller that exposes CRUD endpoints for elective courses and corresponding integration tests.

Files added

- `src/elective-course/elective-course.controller.ts` — Controller implementing POST/GET/PATCH/DELETE endpoints wired to the existing `ElectiveCourseService` and DTOs.
- `src/elective-course/elective-course.controller.spec.ts` — Integration tests using in-memory sqlite and overriding `JwtAuthGuard` for test convenience.
- `COMMIT_MESSAGE.md` — Conventional commit message for the change (added here for convenience).

### Motivation

Frontend clients and other API consumers need a simple, standardized interface to manage elective courses. The service layer already exists; this controller exposes it over HTTP and enforces input validation.

### Implementation details

- Uses existing DTOs `CreateElectiveCourseDto` and `UpdateElectiveCourseDto` (class-validator decorators provide validation).
- Protects write endpoints (create/update/delete) with `JwtAuthGuard`.
- Marks read endpoints (list/get single) as public via `@Public()` decorator so they’re accessible without auth.
- Response format standardized to: `{ status: 'success', message: string, data: any }`.
- Basic `category` and `isActive` query filtering is applied in-controller to avoid breaking current service signature; future improvement: move filters into the service and apply DB-level filtering.

Closed: #398 