### PR TITLE
docs: fix invalid git clone command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ The platform is designed for educational institutions, online learning platforms
 ### 1. Clone the Repository
 
 ```bash
-git clone https://github.com/https://github.com/StarkMindsHQ/strellerminds-backend.git
+git clone https://github.com/StarkMindsHQ/StrellerMinds-Backend.git
 cd strellerminds-backend
 ```
 


### PR DESCRIPTION
### What was changed
Fixed an invalid `git clone` command in the README that contained a duplicated GitHub URL.

### Why this change
The previous clone command would fail for new contributors trying to set up the project locally.  
Correcting this improves onboarding and avoids confusion during initial setup.

### Before
git clone https://github.com/https://github.com/StarkMindsHQ/strellerminds-backend.git

### After
git clone https://github.com/StarkMindsHQ/strellerminds-backend.git

No other changes were made.
