### PR TITLE
feat(course): implement advanced content management system (#530)

### DIFF
--- a/src/course/content-management.controller.ts
+++ b/src/course/content-management.controller.ts
@@ -1,0 +1,151 @@
+import { Body, Controller, Get, Param, ParseIntPipe, Patch, Post, Query } from '@nestjs/common';
+import {
+  AddCollaboratorDto,
+  CreateContentDto,
+  CreateContentFromTemplateDto,
+  CreateTemplateDto,
+  RequestApprovalDto,
+  ReviewContentDto,
+  TrackContentEngagementDto,
+  UpdateContentDto,
+} from './dto/content-management.dto';
+import { CollaborationRole } from './enums/collaboration-role.enum';
+import { ContentFormat } from './enums/content-format.enum';
+import { ContentAnalyticsService } from './services/content-analytics.service';
+import { ContentApprovalService } from './services/content-approval.service';
+import { ContentCollaborationService } from './services/content-collaboration.service';
+import { ContentManagementService } from './services/content-management.service';
+import { ContentVersioningService } from './services/content-versioning.service';
+
+@Controller('courses/content')
+export class ContentManagementController {
+  constructor(
+    private readonly contentManagementService: ContentManagementService,
+    private readonly contentVersioningService: ContentVersioningService,
+    private readonly contentCollaborationService: ContentCollaborationService,
+    private readonly contentApprovalService: ContentApprovalService,
+    private readonly contentAnalyticsService: ContentAnalyticsService,
+  ) {}
+
+  @Post()
+  createContent(@Body() dto: CreateContentDto) {
+    return this.contentManagementService.createContent(dto);
+  }
+
+  @Patch(':contentId')
+  updateContent(@Param('contentId') contentId: string, @Body() dto: UpdateContentDto) {
+    return this.contentManagementService.updateContent(contentId, dto);
+  }
+
+  @Get(':contentId')
+  getContent(@Param('contentId') contentId: string) {
+    return this.contentManagementService.getContentById(contentId);
+  }
+
+  @Get('lesson/:lessonId')
+  getLessonContents(@Param('lessonId') lessonId: string) {
+    return this.contentManagementService.listLessonContents(lessonId);
+  }
+
+  @Post('templates')
+  createTemplate(@Body() dto: CreateTemplateDto) {
+    return this.contentManagementService.createTemplate(dto);
+  }
+
+  @Get('templates/all')
+  listTemplates(@Query('format') format?: ContentFormat) {
+    return this.contentManagementService.listTemplates(format);
+  }
+
+  @Post('templates/reuse')
+  createFromTemplate(@Body() dto: CreateContentFromTemplateDto) {
+    return this.contentManagementService.createFromTemplate(dto);
+  }
+
+  @Get(':contentId/versions')
+  getHistory(@Param('contentId') contentId: string) {
+    return this.contentVersioningService.getHistory(contentId);
+  }
+
+  @Post(':contentId/versions/:version/restore')
+  restoreVersion(
+    @Param('contentId') contentId: string,
+    @Param('version', ParseIntPipe) version: number,
+    @Body('restoredBy') restoredBy?: string,
+  ) {
+    return this.contentVersioningService.restoreVersion(contentId, version, restoredBy);
+  }
+
+  @Get(':contentId/versions/compare')
+  compareVersions(
+    @Param('contentId') contentId: string,
+    @Query('from', ParseIntPipe) fromVersion: number,
+    @Query('to', ParseIntPipe) toVersion: number,
+  ) {
+    return this.contentVersioningService.compareVersions(contentId, fromVersion, toVersion);
+  }
+
+  @Post(':contentId/collaborators')
+  addCollaborator(@Param('contentId') contentId: string, @Body() dto: AddCollaboratorDto) {
+    return this.contentCollaborationService.addCollaborator(contentId, dto);
+  }
+
+  @Get(':contentId/collaborators')
+  listCollaborators(@Param('contentId') contentId: string) {
+    return this.contentCollaborationService.listCollaborators(contentId);
+  }
+
+  @Patch(':contentId/collaborators/:userId')
+  updateCollaboratorRole(
+    @Param('contentId') contentId: string,
+    @Param('userId') userId: string,
+    @Body('role') role: CollaborationRole,
+  ) {
+    return this.contentCollaborationService.updateRole(contentId, userId, role);
+  }
+
+  @Post(':contentId/collaborators/:userId/remove')
+  removeCollaborator(@Param('contentId') contentId: string, @Param('userId') userId: string) {
+    return this.contentCollaborationService.removeCollaborator(contentId, userId);
+  }
+
+  @Post(':contentId/collaborators/:userId/edit-activity')
+  markEditActivity(@Param('contentId') contentId: string, @Param('userId') userId: string) {
+    return this.contentCollaborationService.markEditActivity(contentId, userId);
+  }
+
+  @Post(':contentId/approval/request')
+  requestApproval(@Param('contentId') contentId: string, @Body() dto: RequestApprovalDto) {
+    return this.contentApprovalService.requestApproval(contentId, dto.comments);
+  }
+
+  @Post(':contentId/approval/review')
+  reviewContent(@Param('contentId') contentId: string, @Body() dto: ReviewContentDto) {
+    return this.contentApprovalService.reviewContent(contentId, dto);
+  }
+
+  @Post(':contentId/publish')
+  publishApprovedContent(@Param('contentId') contentId: string) {
+    return this.contentApprovalService.publishApprovedContent(contentId);
+  }
+
+  @Get(':contentId/approval/history')
+  getApprovalHistory(@Param('contentId') contentId: string) {
+    return this.contentApprovalService.getApprovalHistory(contentId);
+  }
+
+  @Post(':contentId/analytics/track')
+  trackEngagement(@Param('contentId') contentId: string, @Body() dto: TrackContentEngagementDto) {
+    return this.contentAnalyticsService.trackEngagement(contentId, dto);
+  }
+
+  @Get(':contentId/analytics/summary')
+  getEngagementSummary(@Param('contentId') contentId: string) {
+    return this.contentAnalyticsService.getEngagementSummary(contentId);
+  }
+
+  @Get('analytics/top-performing')
+  getTopPerforming(@Query('limit') limit?: number) {
+    return this.contentAnalyticsService.getTopPerformingContents(limit ? Number(limit) : 10);
+  }
+}

--- a/src/course/course.module.ts
+++ b/src/course/course.module.ts
@@ -1,18 +1,56 @@
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { CourseController } from './course.controller';
+import { ContentManagementController } from './content-management.controller';
 import { CourseModule as CourseModuleEntity } from './entities/module.entity';
 import { CourseService } from './course.service';
 import { CourseVersion } from './entities/course-version.entity';
 import { Course } from './entities/course.entity';
 import { Enrollment } from './entities/enrollment.entity';
 import { Lesson } from './entities/lesson.entity';
+import { CourseContent } from './entities/course-content.entity';
+import { ContentVersion } from './entities/content-version.entity';
+import { ContentCollaboration } from './entities/content-collaboration.entity';
+import { ContentTemplate } from './entities/content-template.entity';
+import { ContentApproval } from './entities/content-approval.entity';
+import { ContentAnalytics } from './entities/content-analytics.entity';
+import { ContentManagementService } from './services/content-management.service';
+import { ContentVersioningService } from './services/content-versioning.service';
+import { ContentCollaborationService } from './services/content-collaboration.service';
+import { ContentApprovalService } from './services/content-approval.service';
+import { ContentAnalyticsService } from './services/content-analytics.service';
 import { Module } from '@nestjs/common/decorators';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Course, CourseModuleEntity, Lesson, Enrollment, CourseVersion]),
+    TypeOrmModule.forFeature([
+      Course,
+      CourseModuleEntity,
+      Lesson,
+      Enrollment,
+      CourseVersion,
+      CourseContent,
+      ContentVersion,
+      ContentCollaboration,
+      ContentTemplate,
+      ContentApproval,
+      ContentAnalytics,
+    ]),
   ],
-  controllers: [CourseController],
-  providers: [CourseService],
+  controllers: [CourseController, ContentManagementController],
+  providers: [
+    CourseService,
+    ContentManagementService,
+    ContentVersioningService,
+    ContentCollaborationService,
+    ContentApprovalService,
+    ContentAnalyticsService,
+  ],
+  exports: [
+    ContentManagementService,
+    ContentVersioningService,
+    ContentCollaborationService,
+    ContentApprovalService,
+    ContentAnalyticsService,
+  ],
 })
 export class CourseModule {}

--- a/src/course/dto/content-management.dto.ts
+++ b/src/course/dto/content-management.dto.ts
@@ -1,0 +1,155 @@
+import {
+  IsBoolean,
+  IsEnum,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  Min,
+} from 'class-validator';
+import { PartialType } from '@nestjs/swagger';
+import { ContentFormat } from '../enums/content-format.enum';
+import { CollaborationRole } from '../enums/collaboration-role.enum';
+import { ApprovalDecision } from '../enums/approval-decision.enum';
+
+export class CreateContentDto {
+  @IsUUID()
+  lessonId: string;
+
+  @IsString()
+  title: string;
+
+  @IsEnum(ContentFormat)
+  format: ContentFormat;
+
+  @IsOptional()
+  @IsObject()
+  body?: Record<string, any>;
+
+  @IsOptional()
+  @IsString()
+  videoUrl?: string;
+
+  @IsOptional()
+  @IsObject()
+  interactiveConfig?: Record<string, any>;
+
+  @IsOptional()
+  @IsBoolean()
+  reusable?: boolean;
+
+  @IsOptional()
+  @IsUUID()
+  templateId?: string;
+
+  @IsOptional()
+  @IsString()
+  createdBy?: string;
+
+  @IsOptional()
+  @IsString()
+  changeSummary?: string;
+}
+
+export class UpdateContentDto extends PartialType(CreateContentDto) {
+  @IsOptional()
+  @IsString()
+  updatedBy?: string;
+}
+
+export class CreateTemplateDto {
+  @IsString()
+  name: string;
+
+  @IsOptional()
+  @IsString()
+  description?: string;
+
+  @IsEnum(ContentFormat)
+  format: ContentFormat;
+
+  @IsObject()
+  blueprint: Record<string, any>;
+
+  @IsOptional()
+  @IsBoolean()
+  isGlobal?: boolean;
+
+  @IsOptional()
+  @IsString()
+  createdBy?: string;
+}
+
+export class CreateContentFromTemplateDto {
+  @IsUUID()
+  templateId: string;
+
+  @IsUUID()
+  lessonId: string;
+
+  @IsOptional()
+  @IsString()
+  title?: string;
+
+  @IsOptional()
+  @IsString()
+  createdBy?: string;
+}
+
+export class AddCollaboratorDto {
+  @IsString()
+  userId: string;
+
+  @IsEnum(CollaborationRole)
+  role: CollaborationRole;
+}
+
+export class ReviewContentDto {
+  @IsString()
+  reviewerId: string;
+
+  @IsEnum(ApprovalDecision)
+  decision: ApprovalDecision;
+
+  @IsOptional()
+  @IsString()
+  comments?: string;
+}
+
+export class RequestApprovalDto {
+  @IsOptional()
+  @IsString()
+  comments?: string;
+}
+
+export class TrackContentEngagementDto {
+  @IsOptional()
+  @IsString()
+  viewerId?: string;
+
+  @IsOptional()
+  @IsString()
+  eventType?: string;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  viewDurationSeconds?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  interactions?: number;
+
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(100)
+  completionPercent?: number;
+
+  @IsOptional()
+  @IsObject()
+  metadata?: Record<string, any>;
+}

--- a/src/course/entities/content-analytics.entity.ts
+++ b/src/course/entities/content-analytics.entity.ts
@@ -1,0 +1,49 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { CourseContent } from './course-content.entity';
+
+@Entity('content_analytics')
+@Index(['contentId', 'createdAt'])
+@Index(['eventType'])
+export class ContentAnalytics {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  contentId: string;
+
+  @ManyToOne(() => CourseContent, (content) => content.analytics, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'contentId' })
+  content: CourseContent;
+
+  @Column({ nullable: true })
+  viewerId: string;
+
+  @Column({ default: 'view' })
+  eventType: string;
+
+  @Column({ type: 'float', default: 0 })
+  engagementScore: number;
+
+  @Column({ type: 'float', default: 0 })
+  completionPercent: number;
+
+  @Column({ default: 0 })
+  viewDurationSeconds: number;
+
+  @Column({ default: 0 })
+  interactions: number;
+
+  @Column({ type: 'json', nullable: true })
+  metadata: Record<string, any>;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/course/entities/content-approval.entity.ts
+++ b/src/course/entities/content-approval.entity.ts
@@ -1,0 +1,44 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { CourseContent } from './course-content.entity';
+import { ContentStatus } from '../enums/content-status.enum';
+import { ApprovalDecision } from '../enums/approval-decision.enum';
+
+@Entity('content_approvals')
+@Index(['contentId', 'requestedAt'])
+export class ContentApproval {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  contentId: string;
+
+  @ManyToOne(() => CourseContent, (content) => content.approvals, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'contentId' })
+  content: CourseContent;
+
+  @Column({ type: 'enum', enum: ContentStatus, default: ContentStatus.IN_REVIEW })
+  status: ContentStatus;
+
+  @Column({ type: 'enum', enum: ApprovalDecision, nullable: true })
+  decision: ApprovalDecision;
+
+  @Column({ nullable: true })
+  reviewerId: string;
+
+  @Column({ type: 'text', nullable: true })
+  comments: string;
+
+  @CreateDateColumn()
+  requestedAt: Date;
+
+  @Column({ type: 'timestamp', nullable: true })
+  decidedAt: Date;
+}

--- a/src/course/entities/content-collaboration.entity.ts
+++ b/src/course/entities/content-collaboration.entity.ts
@@ -1,0 +1,44 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+import { CourseContent } from './course-content.entity';
+import { CollaborationRole } from '../enums/collaboration-role.enum';
+
+@Entity('content_collaborations')
+@Index(['contentId', 'userId'], { unique: true })
+export class ContentCollaboration {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  contentId: string;
+
+  @ManyToOne(() => CourseContent, (content) => content.collaborators, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'contentId' })
+  content: CourseContent;
+
+  @Column()
+  userId: string;
+
+  @Column({ type: 'enum', enum: CollaborationRole, default: CollaborationRole.EDITOR })
+  role: CollaborationRole;
+
+  @Column({ default: true })
+  isActive: boolean;
+
+  @Column({ type: 'timestamp', nullable: true })
+  lastEditedAt: Date;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/course/entities/content-template.entity.ts
+++ b/src/course/entities/content-template.entity.ts
@@ -1,0 +1,48 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  CreateDateColumn,
+  UpdateDateColumn,
+  OneToMany,
+  Index,
+} from 'typeorm';
+import { ContentFormat } from '../enums/content-format.enum';
+import { CourseContent } from './course-content.entity';
+
+@Entity('content_templates')
+@Index(['format', 'isGlobal'])
+export class ContentTemplate {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ unique: true })
+  name: string;
+
+  @Column({ type: 'text', nullable: true })
+  description: string;
+
+  @Column({ type: 'enum', enum: ContentFormat })
+  format: ContentFormat;
+
+  @Column({ type: 'json' })
+  blueprint: Record<string, any>;
+
+  @Column({ default: 0 })
+  usageCount: number;
+
+  @Column({ default: false })
+  isGlobal: boolean;
+
+  @Column({ nullable: true })
+  createdBy: string;
+
+  @OneToMany(() => CourseContent, (content) => content.template)
+  contents: CourseContent[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/course/entities/content-version.entity.ts
+++ b/src/course/entities/content-version.entity.ts
@@ -1,0 +1,39 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  CreateDateColumn,
+  Index,
+} from 'typeorm';
+import { CourseContent } from './course-content.entity';
+
+@Entity('content_versions')
+@Index(['contentId', 'version'], { unique: true })
+export class ContentVersion {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  contentId: string;
+
+  @ManyToOne(() => CourseContent, (content) => content.versions, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'contentId' })
+  content: CourseContent;
+
+  @Column()
+  version: number;
+
+  @Column({ type: 'json' })
+  snapshot: Record<string, any>;
+
+  @Column({ type: 'text', nullable: true })
+  changeSummary: string;
+
+  @Column({ nullable: true })
+  createdBy: string;
+
+  @CreateDateColumn()
+  createdAt: Date;
+}

--- a/src/course/entities/course-content.entity.ts
+++ b/src/course/entities/course-content.entity.ts
@@ -1,0 +1,89 @@
+import {
+  Entity,
+  PrimaryGeneratedColumn,
+  Column,
+  ManyToOne,
+  OneToMany,
+  JoinColumn,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+import { Lesson } from './lesson.entity';
+import { ContentFormat } from '../enums/content-format.enum';
+import { ContentStatus } from '../enums/content-status.enum';
+import { ContentTemplate } from './content-template.entity';
+import { ContentVersion } from './content-version.entity';
+import { ContentCollaboration } from './content-collaboration.entity';
+import { ContentApproval } from './content-approval.entity';
+import { ContentAnalytics } from './content-analytics.entity';
+
+@Entity('course_contents')
+@Index(['lessonId', 'format'])
+@Index(['status', 'updatedAt'])
+export class CourseContent {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column({ type: 'uuid' })
+  lessonId: string;
+
+  @ManyToOne(() => Lesson, { onDelete: 'CASCADE' })
+  @JoinColumn({ name: 'lessonId' })
+  lesson: Lesson;
+
+  @Column()
+  title: string;
+
+  @Column({ type: 'enum', enum: ContentFormat })
+  format: ContentFormat;
+
+  @Column({ type: 'json', nullable: true })
+  body: Record<string, any>;
+
+  @Column({ nullable: true })
+  videoUrl: string;
+
+  @Column({ type: 'json', nullable: true })
+  interactiveConfig: Record<string, any>;
+
+  @Column({ default: false })
+  reusable: boolean;
+
+  @Column({ type: 'uuid', nullable: true })
+  templateId: string;
+
+  @ManyToOne(() => ContentTemplate, (template) => template.contents, { nullable: true, onDelete: 'SET NULL' })
+  @JoinColumn({ name: 'templateId' })
+  template: ContentTemplate;
+
+  @Column({ type: 'enum', enum: ContentStatus, default: ContentStatus.DRAFT })
+  status: ContentStatus;
+
+  @Column({ default: 1 })
+  currentVersion: number;
+
+  @Column({ nullable: true })
+  createdBy: string;
+
+  @Column({ nullable: true })
+  updatedBy: string;
+
+  @OneToMany(() => ContentVersion, (version) => version.content)
+  versions: ContentVersion[];
+
+  @OneToMany(() => ContentCollaboration, (collab) => collab.content)
+  collaborators: ContentCollaboration[];
+
+  @OneToMany(() => ContentApproval, (approval) => approval.content)
+  approvals: ContentApproval[];
+
+  @OneToMany(() => ContentAnalytics, (analytics) => analytics.content)
+  analytics: ContentAnalytics[];
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/src/course/entities/lesson.entity.ts
+++ b/src/course/entities/lesson.entity.ts
@@ -1,5 +1,6 @@
-import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne, OneToMany } from 'typeorm';
 import { CourseModule } from './module.entity';
+import { CourseContent } from './course-content.entity';
 
 @Entity()
 export class Lesson {
@@ -22,4 +23,9 @@ export class Lesson {
     onDelete: 'CASCADE',
   })
   module: CourseModule;
+
+  @OneToMany(() => CourseContent, (content) => content.lesson, {
+    cascade: true,
+  })
+  contents: CourseContent[];
 }

--- a/src/course/enums/approval-decision.enum.ts
+++ b/src/course/enums/approval-decision.enum.ts
@@ -1,0 +1,5 @@
+export enum ApprovalDecision {
+  APPROVED = 'approved',
+  REJECTED = 'rejected',
+  CHANGES_REQUESTED = 'changes_requested',
+}

--- a/src/course/enums/collaboration-role.enum.ts
+++ b/src/course/enums/collaboration-role.enum.ts
@@ -1,0 +1,6 @@
+export enum CollaborationRole {
+  OWNER = 'owner',
+  EDITOR = 'editor',
+  REVIEWER = 'reviewer',
+  VIEWER = 'viewer',
+}

--- a/src/course/enums/content-format.enum.ts
+++ b/src/course/enums/content-format.enum.ts
@@ -1,0 +1,5 @@
+export enum ContentFormat {
+  VIDEO = 'video',
+  TEXT = 'text',
+  INTERACTIVE = 'interactive',
+}

--- a/src/course/enums/content-status.enum.ts
+++ b/src/course/enums/content-status.enum.ts
@@ -1,0 +1,8 @@
+export enum ContentStatus {
+  DRAFT = 'draft',
+  IN_REVIEW = 'in_review',
+  APPROVED = 'approved',
+  PUBLISHED = 'published',
+  REJECTED = 'rejected',
+  CHANGES_REQUESTED = 'changes_requested',
+}

--- a/src/course/services/content-analytics.service.spec.ts
+++ b/src/course/services/content-analytics.service.spec.ts
@@ -1,0 +1,47 @@
+import { NotFoundException } from '@nestjs/common';
+import { ContentAnalyticsService } from './content-analytics.service';
+
+describe('ContentAnalyticsService', () => {
+  let service: ContentAnalyticsService;
+  let contentRepo: any;
+  let analyticsRepo: any;
+
+  beforeEach(() => {
+    contentRepo = {
+      findOne: jest.fn(),
+    };
+    analyticsRepo = {
+      create: jest.fn((v) => v),
+      save: jest.fn((v) => Promise.resolve(v)),
+      find: jest.fn(),
+      createQueryBuilder: jest.fn(),
+    };
+
+    service = new ContentAnalyticsService(contentRepo, analyticsRepo);
+  });
+
+  it('tracks analytics with computed engagement score', async () => {
+    contentRepo.findOne.mockResolvedValue({ id: 'c1' });
+    const event = await service.trackEngagement('c1', {
+      completionPercent: 80,
+      interactions: 4,
+      viewDurationSeconds: 300,
+    });
+
+    expect(event.engagementScore).toBeGreaterThan(0);
+    expect(analyticsRepo.save).toHaveBeenCalled();
+  });
+
+  it('returns zeroed summary when no events exist', async () => {
+    contentRepo.findOne.mockResolvedValue({ id: 'c1' });
+    analyticsRepo.find.mockResolvedValue([]);
+
+    const summary = await service.getEngagementSummary('c1');
+    expect(summary.totalEvents).toBe(0);
+  });
+
+  it('throws for unknown content', async () => {
+    contentRepo.findOne.mockResolvedValue(null);
+    await expect(service.getEngagementSummary('missing')).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/src/course/services/content-analytics.service.ts
+++ b/src/course/services/content-analytics.service.ts
@@ -1,0 +1,105 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { TrackContentEngagementDto } from '../dto/content-management.dto';
+import { ContentAnalytics } from '../entities/content-analytics.entity';
+import { CourseContent } from '../entities/course-content.entity';
+
+@Injectable()
+export class ContentAnalyticsService {
+  constructor(
+    @InjectRepository(CourseContent)
+    private readonly contentRepo: Repository<CourseContent>,
+    @InjectRepository(ContentAnalytics)
+    private readonly analyticsRepo: Repository<ContentAnalytics>,
+  ) {}
+
+  async trackEngagement(contentId: string, dto: TrackContentEngagementDto): Promise<ContentAnalytics> {
+    const content = await this.contentRepo.findOne({ where: { id: contentId } });
+    if (!content) {
+      throw new NotFoundException('Content not found');
+    }
+
+    const completionPercent = dto.completionPercent ?? 0;
+    const interactions = dto.interactions ?? 0;
+    const viewDurationSeconds = dto.viewDurationSeconds ?? 0;
+    const engagementScore = this.calculateEngagementScore(
+      completionPercent,
+      interactions,
+      viewDurationSeconds,
+    );
+
+    return this.analyticsRepo.save(
+      this.analyticsRepo.create({
+        contentId,
+        viewerId: dto.viewerId,
+        eventType: dto.eventType || 'view',
+        completionPercent,
+        interactions,
+        viewDurationSeconds,
+        engagementScore,
+        metadata: dto.metadata,
+      }),
+    );
+  }
+
+  async getEngagementSummary(contentId: string) {
+    const content = await this.contentRepo.findOne({ where: { id: contentId } });
+    if (!content) {
+      throw new NotFoundException('Content not found');
+    }
+
+    const events = await this.analyticsRepo.find({ where: { contentId } });
+    if (events.length === 0) {
+      return {
+        contentId,
+        totalEvents: 0,
+        averageEngagementScore: 0,
+        averageCompletionPercent: 0,
+        totalViewDurationSeconds: 0,
+        totalInteractions: 0,
+      };
+    }
+
+    const totalEngagement = events.reduce((acc, row) => acc + row.engagementScore, 0);
+    const totalCompletion = events.reduce((acc, row) => acc + row.completionPercent, 0);
+    const totalDuration = events.reduce((acc, row) => acc + row.viewDurationSeconds, 0);
+    const totalInteractions = events.reduce((acc, row) => acc + row.interactions, 0);
+
+    return {
+      contentId,
+      totalEvents: events.length,
+      averageEngagementScore: Number((totalEngagement / events.length).toFixed(2)),
+      averageCompletionPercent: Number((totalCompletion / events.length).toFixed(2)),
+      totalViewDurationSeconds: totalDuration,
+      totalInteractions,
+    };
+  }
+
+  async getTopPerformingContents(limit = 10) {
+    const rows = await this.analyticsRepo
+      .createQueryBuilder('analytics')
+      .select('analytics.contentId', 'contentId')
+      .addSelect('AVG(analytics.engagementScore)', 'averageEngagementScore')
+      .addSelect('COUNT(*)', 'totalEvents')
+      .groupBy('analytics.contentId')
+      .orderBy('AVG(analytics.engagementScore)', 'DESC')
+      .limit(limit)
+      .getRawMany();
+
+    return rows.map((row) => ({
+      contentId: row.contentId,
+      averageEngagementScore: Number(row.averageEngagementScore || 0),
+      totalEvents: Number(row.totalEvents || 0),
+    }));
+  }
+
+  private calculateEngagementScore(
+    completionPercent: number,
+    interactions: number,
+    viewDurationSeconds: number,
+  ): number {
+    const score = completionPercent * 0.6 + interactions * 5 + Math.min(viewDurationSeconds / 12, 40);
+    return Number(Math.max(0, Math.min(100, score)).toFixed(2));
+  }
+}

--- a/src/course/services/content-approval.service.spec.ts
+++ b/src/course/services/content-approval.service.spec.ts
@@ -1,0 +1,64 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ContentApprovalService } from './content-approval.service';
+import { ApprovalDecision } from '../enums/approval-decision.enum';
+import { ContentStatus } from '../enums/content-status.enum';
+
+describe('ContentApprovalService', () => {
+  let service: ContentApprovalService;
+  let contentRepo: any;
+  let approvalRepo: any;
+
+  beforeEach(() => {
+    contentRepo = {
+      findOne: jest.fn(),
+      save: jest.fn((v) => Promise.resolve(v)),
+    };
+    approvalRepo = {
+      create: jest.fn((v) => v),
+      save: jest.fn((v) => Promise.resolve(v)),
+      findOne: jest.fn(),
+      find: jest.fn(),
+    };
+
+    service = new ContentApprovalService(contentRepo, approvalRepo);
+  });
+
+  it('requests approval and moves content to review', async () => {
+    contentRepo.findOne.mockResolvedValue({ id: 'c1', status: ContentStatus.DRAFT });
+    await service.requestApproval('c1', 'ready for review');
+
+    expect(contentRepo.save).toHaveBeenCalled();
+    expect(approvalRepo.save).toHaveBeenCalled();
+  });
+
+  it('approves content through review workflow', async () => {
+    contentRepo.findOne.mockResolvedValue({ id: 'c1', status: ContentStatus.IN_REVIEW });
+    approvalRepo.findOne.mockResolvedValue({
+      id: 'a1',
+      contentId: 'c1',
+      status: ContentStatus.IN_REVIEW,
+    });
+
+    const result = await service.reviewContent('c1', {
+      reviewerId: 'u1',
+      decision: ApprovalDecision.APPROVED,
+    });
+
+    expect(result.status).toBe(ContentStatus.APPROVED);
+  });
+
+  it('blocks publish when content is not approved', async () => {
+    contentRepo.findOne.mockResolvedValue({ id: 'c1', status: ContentStatus.DRAFT });
+    await expect(service.publishApprovedContent('c1')).rejects.toBeInstanceOf(BadRequestException);
+  });
+
+  it('throws when content not found', async () => {
+    contentRepo.findOne.mockResolvedValue(null);
+    await expect(
+      service.reviewContent('missing', {
+        reviewerId: 'u1',
+        decision: ApprovalDecision.REJECTED,
+      }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+});

--- a/src/course/services/content-approval.service.ts
+++ b/src/course/services/content-approval.service.ts
@@ -1,0 +1,90 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { ReviewContentDto } from '../dto/content-management.dto';
+import { ContentApproval } from '../entities/content-approval.entity';
+import { CourseContent } from '../entities/course-content.entity';
+import { ApprovalDecision } from '../enums/approval-decision.enum';
+import { ContentStatus } from '../enums/content-status.enum';
+
+@Injectable()
+export class ContentApprovalService {
+  constructor(
+    @InjectRepository(CourseContent)
+    private readonly contentRepo: Repository<CourseContent>,
+    @InjectRepository(ContentApproval)
+    private readonly approvalRepo: Repository<ContentApproval>,
+  ) {}
+
+  async requestApproval(contentId: string, comments?: string): Promise<ContentApproval> {
+    const content = await this.contentRepo.findOne({ where: { id: contentId } });
+    if (!content) {
+      throw new NotFoundException('Content not found');
+    }
+
+    content.status = ContentStatus.IN_REVIEW;
+    await this.contentRepo.save(content);
+
+    return this.approvalRepo.save(
+      this.approvalRepo.create({
+        contentId,
+        status: ContentStatus.IN_REVIEW,
+        comments,
+      }),
+    );
+  }
+
+  async reviewContent(contentId: string, dto: ReviewContentDto): Promise<ContentApproval> {
+    const content = await this.contentRepo.findOne({ where: { id: contentId } });
+    if (!content) {
+      throw new NotFoundException('Content not found');
+    }
+
+    const pending = await this.approvalRepo.findOne({
+      where: { contentId, status: ContentStatus.IN_REVIEW },
+      order: { requestedAt: 'DESC' },
+    });
+    if (!pending) {
+      throw new BadRequestException('No pending approval found');
+    }
+
+    pending.decision = dto.decision;
+    pending.reviewerId = dto.reviewerId;
+    pending.comments = dto.comments || pending.comments;
+    pending.decidedAt = new Date();
+
+    if (dto.decision === ApprovalDecision.APPROVED) {
+      pending.status = ContentStatus.APPROVED;
+      content.status = ContentStatus.APPROVED;
+    } else if (dto.decision === ApprovalDecision.REJECTED) {
+      pending.status = ContentStatus.REJECTED;
+      content.status = ContentStatus.REJECTED;
+    } else {
+      pending.status = ContentStatus.CHANGES_REQUESTED;
+      content.status = ContentStatus.CHANGES_REQUESTED;
+    }
+
+    await this.contentRepo.save(content);
+    return this.approvalRepo.save(pending);
+  }
+
+  async publishApprovedContent(contentId: string): Promise<CourseContent> {
+    const content = await this.contentRepo.findOne({ where: { id: contentId } });
+    if (!content) {
+      throw new NotFoundException('Content not found');
+    }
+    if (content.status !== ContentStatus.APPROVED) {
+      throw new BadRequestException('Only approved content can be published');
+    }
+
+    content.status = ContentStatus.PUBLISHED;
+    return this.contentRepo.save(content);
+  }
+
+  async getApprovalHistory(contentId: string): Promise<ContentApproval[]> {
+    return this.approvalRepo.find({
+      where: { contentId },
+      order: { requestedAt: 'DESC' },
+    });
+  }
+}

--- a/src/course/services/content-collaboration.service.spec.ts
+++ b/src/course/services/content-collaboration.service.spec.ts
@@ -1,0 +1,57 @@
+import { NotFoundException } from '@nestjs/common';
+import { ContentCollaborationService } from './content-collaboration.service';
+import { CollaborationRole } from '../enums/collaboration-role.enum';
+
+describe('ContentCollaborationService', () => {
+  let service: ContentCollaborationService;
+  let contentRepo: any;
+  let collaborationRepo: any;
+
+  beforeEach(() => {
+    contentRepo = {
+      findOne: jest.fn(),
+    };
+    collaborationRepo = {
+      findOne: jest.fn(),
+      find: jest.fn(),
+      create: jest.fn((v) => v),
+      save: jest.fn((v) => Promise.resolve(v)),
+    };
+
+    service = new ContentCollaborationService(contentRepo, collaborationRepo);
+  });
+
+  it('adds collaborator when content exists', async () => {
+    contentRepo.findOne.mockResolvedValue({ id: 'content-1' });
+    collaborationRepo.findOne.mockResolvedValue(null);
+
+    const result = await service.addCollaborator('content-1', {
+      userId: 'user-1',
+      role: CollaborationRole.EDITOR,
+    });
+
+    expect(result.userId).toBe('user-1');
+    expect(collaborationRepo.save).toHaveBeenCalled();
+  });
+
+  it('throws when adding collaborator to unknown content', async () => {
+    contentRepo.findOne.mockResolvedValue(null);
+
+    await expect(
+      service.addCollaborator('missing', {
+        userId: 'user-1',
+        role: CollaborationRole.EDITOR,
+      }),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('marks collaborator as inactive on removal', async () => {
+    collaborationRepo.findOne.mockResolvedValue({
+      contentId: 'content-1',
+      userId: 'user-1',
+      isActive: true,
+    });
+    const result = await service.removeCollaborator('content-1', 'user-1');
+    expect(result.isActive).toBe(false);
+  });
+});

--- a/src/course/services/content-collaboration.service.ts
+++ b/src/course/services/content-collaboration.service.ts
@@ -1,0 +1,87 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { AddCollaboratorDto } from '../dto/content-management.dto';
+import { ContentCollaboration } from '../entities/content-collaboration.entity';
+import { CourseContent } from '../entities/course-content.entity';
+import { CollaborationRole } from '../enums/collaboration-role.enum';
+
+@Injectable()
+export class ContentCollaborationService {
+  constructor(
+    @InjectRepository(CourseContent)
+    private readonly contentRepo: Repository<CourseContent>,
+    @InjectRepository(ContentCollaboration)
+    private readonly collaborationRepo: Repository<ContentCollaboration>,
+  ) {}
+
+  async addCollaborator(contentId: string, dto: AddCollaboratorDto): Promise<ContentCollaboration> {
+    const content = await this.contentRepo.findOne({ where: { id: contentId } });
+    if (!content) {
+      throw new NotFoundException('Content not found');
+    }
+
+    let collaborator = await this.collaborationRepo.findOne({
+      where: { contentId, userId: dto.userId },
+    });
+
+    if (!collaborator) {
+      collaborator = this.collaborationRepo.create({
+        contentId,
+        userId: dto.userId,
+        role: dto.role,
+        isActive: true,
+      });
+    } else {
+      collaborator.role = dto.role;
+      collaborator.isActive = true;
+    }
+
+    return this.collaborationRepo.save(collaborator);
+  }
+
+  async listCollaborators(contentId: string): Promise<ContentCollaboration[]> {
+    return this.collaborationRepo.find({
+      where: { contentId, isActive: true },
+      order: { updatedAt: 'DESC' },
+    });
+  }
+
+  async updateRole(
+    contentId: string,
+    userId: string,
+    role: CollaborationRole,
+  ): Promise<ContentCollaboration> {
+    const collaborator = await this.collaborationRepo.findOne({
+      where: { contentId, userId, isActive: true },
+    });
+    if (!collaborator) {
+      throw new NotFoundException('Collaborator not found');
+    }
+    collaborator.role = role;
+    return this.collaborationRepo.save(collaborator);
+  }
+
+  async removeCollaborator(contentId: string, userId: string): Promise<ContentCollaboration> {
+    const collaborator = await this.collaborationRepo.findOne({
+      where: { contentId, userId, isActive: true },
+    });
+    if (!collaborator) {
+      throw new NotFoundException('Collaborator not found');
+    }
+    collaborator.isActive = false;
+    return this.collaborationRepo.save(collaborator);
+  }
+
+  async markEditActivity(contentId: string, userId: string): Promise<ContentCollaboration> {
+    const collaborator = await this.collaborationRepo.findOne({
+      where: { contentId, userId, isActive: true },
+    });
+    if (!collaborator) {
+      throw new NotFoundException('Collaborator not found');
+    }
+
+    collaborator.lastEditedAt = new Date();
+    return this.collaborationRepo.save(collaborator);
+  }
+}

--- a/src/course/services/content-management.service.spec.ts
+++ b/src/course/services/content-management.service.spec.ts
@@ -1,0 +1,86 @@
+import { BadRequestException, NotFoundException } from '@nestjs/common';
+import { ContentManagementService } from './content-management.service';
+import { ContentFormat } from '../enums/content-format.enum';
+
+describe('ContentManagementService', () => {
+  let service: ContentManagementService;
+  let lessonRepo: any;
+  let contentRepo: any;
+  let versionRepo: any;
+  let templateRepo: any;
+
+  beforeEach(() => {
+    lessonRepo = { findOneBy: jest.fn() };
+    contentRepo = {
+      create: jest.fn((v) => v),
+      save: jest.fn(),
+      findOne: jest.fn(),
+      find: jest.fn(),
+    };
+    versionRepo = {
+      create: jest.fn((v) => v),
+      save: jest.fn(),
+    };
+    templateRepo = {
+      findOne: jest.fn(),
+      create: jest.fn((v) => v),
+      save: jest.fn(),
+      find: jest.fn(),
+    };
+
+    service = new ContentManagementService(lessonRepo, contentRepo, versionRepo, templateRepo);
+  });
+
+  it('creates text content and initial version', async () => {
+    lessonRepo.findOneBy.mockResolvedValue({ id: 'lesson-1' });
+    contentRepo.save.mockResolvedValue({
+      id: 'content-1',
+      lessonId: 'lesson-1',
+      title: 'Intro',
+      format: ContentFormat.TEXT,
+      body: { text: 'hello' },
+      videoUrl: null,
+      interactiveConfig: null,
+      reusable: false,
+      templateId: null,
+      status: 'draft',
+      currentVersion: 1,
+    });
+    contentRepo.findOne.mockResolvedValue({ id: 'content-1' });
+
+    await service.createContent({
+      lessonId: 'lesson-1',
+      title: 'Intro',
+      format: ContentFormat.TEXT,
+      body: { text: 'hello' },
+    } as any);
+
+    expect(versionRepo.save).toHaveBeenCalledTimes(1);
+    expect(contentRepo.save).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws for missing lesson', async () => {
+    lessonRepo.findOneBy.mockResolvedValue(null);
+
+    await expect(
+      service.createContent({
+        lessonId: 'missing',
+        title: 'Intro',
+        format: ContentFormat.TEXT,
+        body: { text: 'hello' },
+      } as any),
+    ).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it('throws for invalid format payload', async () => {
+    lessonRepo.findOneBy.mockResolvedValue({ id: 'lesson-1' });
+
+    await expect(
+      service.createContent({
+        lessonId: 'lesson-1',
+        title: 'Video',
+        format: ContentFormat.VIDEO,
+      } as any),
+    ).rejects.toBeInstanceOf(BadRequestException);
+  });
+});

--- a/src/course/services/content-management.service.ts
+++ b/src/course/services/content-management.service.ts
@@ -1,0 +1,209 @@
+import { BadRequestException, Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Lesson } from '../entities/lesson.entity';
+import { CourseContent } from '../entities/course-content.entity';
+import { ContentVersion } from '../entities/content-version.entity';
+import { ContentTemplate } from '../entities/content-template.entity';
+import { ContentFormat } from '../enums/content-format.enum';
+import {
+  CreateContentDto,
+  CreateContentFromTemplateDto,
+  CreateTemplateDto,
+  UpdateContentDto,
+} from '../dto/content-management.dto';
+
+@Injectable()
+export class ContentManagementService {
+  constructor(
+    @InjectRepository(Lesson)
+    private readonly lessonRepo: Repository<Lesson>,
+    @InjectRepository(CourseContent)
+    private readonly contentRepo: Repository<CourseContent>,
+    @InjectRepository(ContentVersion)
+    private readonly versionRepo: Repository<ContentVersion>,
+    @InjectRepository(ContentTemplate)
+    private readonly templateRepo: Repository<ContentTemplate>,
+  ) {}
+
+  async createContent(dto: CreateContentDto): Promise<CourseContent> {
+    const lesson = await this.lessonRepo.findOneBy({ id: dto.lessonId });
+    if (!lesson) {
+      throw new NotFoundException('Lesson not found');
+    }
+
+    this.validateContentPayload(dto.format, dto.body, dto.videoUrl, dto.interactiveConfig);
+
+    const content = await this.contentRepo.save(
+      this.contentRepo.create({
+        lessonId: dto.lessonId,
+        title: dto.title,
+        format: dto.format,
+        body: dto.body,
+        videoUrl: dto.videoUrl,
+        interactiveConfig: dto.interactiveConfig,
+        reusable: dto.reusable ?? false,
+        templateId: dto.templateId,
+        createdBy: dto.createdBy,
+        updatedBy: dto.createdBy,
+      }),
+    );
+
+    await this.versionRepo.save(
+      this.versionRepo.create({
+        contentId: content.id,
+        version: 1,
+        snapshot: this.snapshot(content),
+        changeSummary: dto.changeSummary || 'Initial content creation',
+        createdBy: dto.createdBy,
+      }),
+    );
+
+    return this.getContentById(content.id);
+  }
+
+  async updateContent(contentId: string, dto: UpdateContentDto): Promise<CourseContent> {
+    const content = await this.getContentById(contentId);
+    const nextFormat = dto.format || content.format;
+    const nextBody = dto.body !== undefined ? dto.body : content.body;
+    const nextVideoUrl = dto.videoUrl !== undefined ? dto.videoUrl : content.videoUrl;
+    const nextInteractive =
+      dto.interactiveConfig !== undefined ? dto.interactiveConfig : content.interactiveConfig;
+    this.validateContentPayload(nextFormat, nextBody, nextVideoUrl, nextInteractive);
+
+    Object.assign(content, {
+      title: dto.title ?? content.title,
+      format: nextFormat,
+      body: nextBody,
+      videoUrl: nextVideoUrl,
+      interactiveConfig: nextInteractive,
+      reusable: dto.reusable ?? content.reusable,
+      templateId: dto.templateId ?? content.templateId,
+      updatedBy: dto.updatedBy ?? content.updatedBy,
+      currentVersion: content.currentVersion + 1,
+    });
+
+    const saved = await this.contentRepo.save(content);
+    await this.versionRepo.save(
+      this.versionRepo.create({
+        contentId: saved.id,
+        version: saved.currentVersion,
+        snapshot: this.snapshot(saved),
+        changeSummary: dto.changeSummary || 'Content updated',
+        createdBy: dto.updatedBy,
+      }),
+    );
+
+    return this.getContentById(saved.id);
+  }
+
+  async getContentById(contentId: string): Promise<CourseContent> {
+    const content = await this.contentRepo.findOne({
+      where: { id: contentId },
+      relations: ['versions', 'collaborators', 'approvals'],
+    });
+    if (!content) {
+      throw new NotFoundException('Content not found');
+    }
+    return content;
+  }
+
+  async listLessonContents(lessonId: string): Promise<CourseContent[]> {
+    return this.contentRepo.find({
+      where: { lessonId },
+      order: { updatedAt: 'DESC' },
+    });
+  }
+
+  async createTemplate(dto: CreateTemplateDto): Promise<ContentTemplate> {
+    const existing = await this.templateRepo.findOne({ where: { name: dto.name } });
+    if (existing) {
+      throw new BadRequestException('Template name already exists');
+    }
+
+    return this.templateRepo.save(
+      this.templateRepo.create({
+        name: dto.name,
+        description: dto.description,
+        format: dto.format,
+        blueprint: dto.blueprint,
+        isGlobal: dto.isGlobal ?? false,
+        createdBy: dto.createdBy,
+      }),
+    );
+  }
+
+  async createFromTemplate(dto: CreateContentFromTemplateDto): Promise<CourseContent> {
+    const template = await this.templateRepo.findOne({ where: { id: dto.templateId } });
+    if (!template) {
+      throw new NotFoundException('Template not found');
+    }
+
+    const lesson = await this.lessonRepo.findOneBy({ id: dto.lessonId });
+    if (!lesson) {
+      throw new NotFoundException('Lesson not found');
+    }
+
+    const blueprint = template.blueprint || {};
+    const payload: CreateContentDto = {
+      lessonId: dto.lessonId,
+      title: dto.title || blueprint.title || template.name,
+      format: template.format,
+      body: blueprint.body,
+      videoUrl: blueprint.videoUrl,
+      interactiveConfig: blueprint.interactiveConfig,
+      reusable: true,
+      templateId: template.id,
+      createdBy: dto.createdBy || template.createdBy,
+      changeSummary: `Created from template: ${template.name}`,
+    };
+
+    const content = await this.createContent(payload);
+    template.usageCount += 1;
+    await this.templateRepo.save(template);
+
+    return content;
+  }
+
+  async listTemplates(format?: ContentFormat): Promise<ContentTemplate[]> {
+    const where = format ? { format } : {};
+    return this.templateRepo.find({
+      where,
+      order: { usageCount: 'DESC', createdAt: 'DESC' },
+    });
+  }
+
+  private validateContentPayload(
+    format: ContentFormat,
+    body?: Record<string, any>,
+    videoUrl?: string,
+    interactiveConfig?: Record<string, any>,
+  ): void {
+    if (format === ContentFormat.VIDEO && !videoUrl) {
+      throw new BadRequestException('videoUrl is required for video content');
+    }
+
+    if (format === ContentFormat.TEXT && (!body || Object.keys(body).length === 0)) {
+      throw new BadRequestException('body is required for text content');
+    }
+
+    if (format === ContentFormat.INTERACTIVE && !interactiveConfig) {
+      throw new BadRequestException(
+        'interactiveConfig is required for interactive content',
+      );
+    }
+  }
+
+  private snapshot(content: CourseContent): Record<string, any> {
+    return {
+      title: content.title,
+      format: content.format,
+      body: content.body,
+      videoUrl: content.videoUrl,
+      interactiveConfig: content.interactiveConfig,
+      reusable: content.reusable,
+      templateId: content.templateId,
+      status: content.status,
+    };
+  }
+}

--- a/src/course/services/content-versioning.service.ts
+++ b/src/course/services/content-versioning.service.ts
@@ -1,0 +1,95 @@
+import { Injectable, NotFoundException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { CourseContent } from '../entities/course-content.entity';
+import { ContentVersion } from '../entities/content-version.entity';
+
+@Injectable()
+export class ContentVersioningService {
+  constructor(
+    @InjectRepository(CourseContent)
+    private readonly contentRepo: Repository<CourseContent>,
+    @InjectRepository(ContentVersion)
+    private readonly versionRepo: Repository<ContentVersion>,
+  ) {}
+
+  async getHistory(contentId: string): Promise<ContentVersion[]> {
+    return this.versionRepo.find({
+      where: { contentId },
+      order: { version: 'DESC' },
+    });
+  }
+
+  async restoreVersion(
+    contentId: string,
+    versionNumber: number,
+    restoredBy?: string,
+  ): Promise<CourseContent> {
+    const content = await this.contentRepo.findOne({ where: { id: contentId } });
+    if (!content) {
+      throw new NotFoundException('Content not found');
+    }
+
+    const version = await this.versionRepo.findOne({
+      where: { contentId, version: versionNumber },
+    });
+    if (!version) {
+      throw new NotFoundException('Version not found');
+    }
+
+    const snapshot = version.snapshot || {};
+    Object.assign(content, {
+      title: snapshot.title ?? content.title,
+      format: snapshot.format ?? content.format,
+      body: snapshot.body,
+      videoUrl: snapshot.videoUrl,
+      interactiveConfig: snapshot.interactiveConfig,
+      reusable: snapshot.reusable ?? content.reusable,
+      templateId: snapshot.templateId ?? content.templateId,
+      status: snapshot.status ?? content.status,
+      updatedBy: restoredBy,
+      currentVersion: content.currentVersion + 1,
+    });
+
+    const saved = await this.contentRepo.save(content);
+    await this.versionRepo.save(
+      this.versionRepo.create({
+        contentId: saved.id,
+        version: saved.currentVersion,
+        snapshot: {
+          title: saved.title,
+          format: saved.format,
+          body: saved.body,
+          videoUrl: saved.videoUrl,
+          interactiveConfig: saved.interactiveConfig,
+          reusable: saved.reusable,
+          templateId: saved.templateId,
+          status: saved.status,
+        },
+        changeSummary: `Restored from version ${versionNumber}`,
+        createdBy: restoredBy,
+      }),
+    );
+
+    return saved;
+  }
+
+  async compareVersions(contentId: string, fromVersion: number, toVersion: number) {
+    const [from, to] = await Promise.all([
+      this.versionRepo.findOne({ where: { contentId, version: fromVersion } }),
+      this.versionRepo.findOne({ where: { contentId, version: toVersion } }),
+    ]);
+
+    if (!from || !to) {
+      throw new NotFoundException('Version comparison target not found');
+    }
+
+    return {
+      contentId,
+      fromVersion: from.version,
+      toVersion: to.version,
+      fromSnapshot: from.snapshot,
+      toSnapshot: to.snapshot,
+    };
+  }
+}


### PR DESCRIPTION
Implements advanced content management in src/course/:
Adds multi-format content support (video, text, interactive)
Adds content versioning/history and restore/compare flows
Adds collaborative editing (roles, collaborator management, edit activity)
Adds content reuse and templating
Adds approval workflow (request, review decision, publish approved content)
Adds content analytics and engagement tracking (events, summary, top-performing)
Adds comprehensive unit tests for new content services
Wires new entities/services/controllers into CourseModule

close #530 