### PR TITLE
Fixed Hardcoded Database Credentials in Environment Example

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -3,18 +3,18 @@ PORT=3000
 
 DATABASE_HOST=localhost
 DATABASE_PORT=5432
-DATABASE_USER=Lagodxy
-DATABASE_PASSWORD=4633922uw8w8w8w
-DATABASE_NAME=StrellerMinds
+DATABASE_USER=your_database_user_here
+DATABASE_PASSWORD=your_database_password_here
+DATABASE_NAME=your_database_name_here
 
 # Authentication
-JWT_SECRET=mysecretJourney
+JWT_SECRET=your_jwt_secret_here
 
-#Claudinary Credentials 
-CLOUDINARY_CLOUD_NAME=ds3czwdtg
-CLOUDINARY_API_KEY=377545627931675
-CLOUDINARY_API_SECRET=pFrg1_s63mhEQ_v9w-IVdDFq3jE
-STELLAR_SECRET_KEY="jgjxvsjxvwjxsjxgskjxksmxjswkxwgxwdcj"
+#Cloudinary Credentials 
+CLOUDINARY_CLOUD_NAME=your_cloud_name_here
+CLOUDINARY_API_KEY=your_cloudinary_api_key_here
+CLOUDINARY_API_SECRET=your_cloudinary_api_secret_here
+STELLAR_SECRET_KEY=your_stellar_secret_key_here
 
 NODE_ENV=development
 EMAIL_ENABLED=false

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,11 @@
+# WARNING: Never commit real credentials to version control.
+# Copy this file to .env and fill in your actual values.
+# Use a secrets manager (e.g., AWS Secrets Manager, Vault) in production.
 DATABASE_HOST=localhost
 DATABASE_PORT=5432
-DATABASE_USER=postgres
-DATABASE_PASSWORD=adetomi.54
-DATABASE_NAME=streller_minds
+DATABASE_USER=your_database_user_here
+DATABASE_PASSWORD=your_database_password_here
+DATABASE_NAME=your_database_name_here
 
 # JWT Configuration
 JWT_SECRET=your_super_secret_jwt_key_here_change_in_production
@@ -148,12 +151,6 @@ VIDEO_PROCESSING_TEMP_DIR=./temp/video-processing
 FFMPEG_PATH=/usr/bin/ffmpeg
 FFPROBE_PATH=/usr/bin/ffprobe
 
-AWS_ACCESS_KEY_ID=test
-AWS_SECRET_ACCESS_KEY=test
-AWS_REGION=us-east-1
-S3_ENDPOINT=http://localhost:4566
-S3_BUCKET_NAME=media-bucket
-
 # Video Security
 VIDEO_TOKEN_EXPIRY=3600
 VIDEO_DRM_ENABLED=false
@@ -192,4 +189,4 @@ OTEL_COLLECTOR_URL=http://localhost:14268/api/traces
 
 ELASTICSEARCH_NODE=http://localhost:9200
 ELASTICSEARCH_USERNAME=elastic
-ELASTICSEARCH_PASSWORD=changeme
+ELASTICSEARCH_PASSWORD=your_elasticsearch_password_here

--- a/.env.locale
+++ b/.env.locale
@@ -3,18 +3,18 @@ PORT=3000
 
 DATABASE_HOST=localhost
 DATABASE_PORT=5432
-DATABASE_USER=Lagodxy
-DATABASE_PASSWORD=4633922uw8w8w8w
-DATABASE_NAME=StrellerMinds
+DATABASE_USER=your_database_user_here
+DATABASE_PASSWORD=your_database_password_here
+DATABASE_NAME=your_database_name_here
 
 # Authentication
-JWT_SECRET=mysecretJourney
+JWT_SECRET=your_jwt_secret_here
 
-#Claudinary Credentials 
-CLOUDINARY_CLOUD_NAME=ds3czwdtg
-CLOUDINARY_API_KEY=377545627931675
-CLOUDINARY_API_SECRET=pFrg1_s63mhEQ_v9w-IVdDFq3jE
-STELLAR_SECRET_KEY="jgjxvsjxvwjxsjxgskjxksmxjswkxwgxwdcj"
+#Cloudinary Credentials 
+CLOUDINARY_CLOUD_NAME=your_cloud_name_here
+CLOUDINARY_API_KEY=your_cloudinary_api_key_here
+CLOUDINARY_API_SECRET=your_cloudinary_api_secret_here
+STELLAR_SECRET_KEY=your_stellar_secret_key_here
 
 NODE_ENV=development
 EMAIL_ENABLED=false

--- a/.env.production.example
+++ b/.env.production.example
@@ -14,7 +14,7 @@ JWT_SECRET=change_this_to_a_strong_secret_in_production
 ENCRYPTION_KEY=change_this_to_a_32_character_string
 
 # Monitoring
-GRAFANA_PASSWORD=admin123
+GRAFANA_PASSWORD=your_grafana_password_here
 
 # Docker Registry
 DOCKER_REGISTRY=localhost:5000


### PR DESCRIPTION
## Changes Made

.env.example — replaced DATABASE_PASSWORD=adetomi.54 with a placeholder, added a security warning comment at the top, replaced ELASTICSEARCH_PASSWORD=changeme, and removed the duplicate AWS_ACCESS_KEY_ID=test / AWS_SECRET_ACCESS_KEY=test block
.env.production.example — replaced GRAFANA_PASSWORD=admin123 with a placeholder
.env.development and .env.locale — scrubbed real DB credentials, JWT secret, Cloudinary API keys, and Stellar secret key, all replaced with safe placeholders

Close #583 