### PR TITLE
Implement API versioning strategy + deprecation/migration + monitoring

### DIFF
--- a/src/documentation/controllers/documentation.controller.ts
+++ b/src/documentation/controllers/documentation.controller.ts
@@ -28,7 +28,7 @@ import { ApiAnalyticsQueryDto } from '../dto/analytics.dto';
 import { NestApplication } from '@nestjs/core';
 
 @ApiTags('Developer Portal')
-@Controller('documentation')
+@Controller({ path: 'documentation', version: '1' })
 @UseGuards(JwtAuthGuard)
 @ApiBearerAuth()
 export class DocumentationController {
@@ -150,6 +150,56 @@ export class DocumentationController {
   @ApiResponse({ status: 200, description: 'Versions retrieved' })
   async getVersions() {
     return this.versioningService.getAllVersions();
+  }
+
+  @Post('versions')
+  @ApiOperation({ summary: 'Create a new API version' })
+  @ApiResponse({ status: 201, description: 'Version created' })
+  async createVersion(
+    @Body('version') version: string,
+    @Body('releaseNotes') releaseNotes?: string,
+    @Body('breakingChanges') breakingChanges?: Array<{ endpoint: string; description: string; migration: string }>,
+  ) {
+    return this.versioningService.createVersion(version, releaseNotes, breakingChanges);
+  }
+
+  @Put('versions/:id/deprecate')
+  @ApiOperation({ summary: 'Deprecate an API version' })
+  @ApiResponse({ status: 200, description: 'Version deprecated' })
+  async deprecateVersion(
+    @Param('id') id: string,
+    @Body('deprecationDate') deprecationDate: string,
+    @Body('sunsetDate') sunsetDate: string,
+  ) {
+    await this.versioningService.deprecateVersion(id, new Date(deprecationDate), new Date(sunsetDate));
+    return { message: `Version ${id} deprecated` };
+  }
+
+  @Get('versions/:id/status')
+  @ApiOperation({ summary: 'Get status of a specific API version' })
+  @ApiResponse({ status: 200, description: 'Version status retrieved' })
+  async getVersionStatus(@Param('id') id: string) {
+    const version = await this.versioningService.getVersion(id);
+    if (!version) {
+      return { status: 'not_found' };
+    }
+    return {
+      id: version.id,
+      version: version.version,
+      status: version.status,
+      deprecationDate: version.deprecationDate,
+      sunsetDate: version.sunsetDate,
+    };
+  }
+
+  @Get('versions/analytics')
+  @ApiOperation({ summary: 'Get API usage by version' })
+  @ApiResponse({ status: 200, description: 'Version analytics retrieved' })
+  async getVersionAnalytics(@Query('startDate') startDate?: string, @Query('endDate') endDate?: string) {
+    return this.analyticsService.getAnalytics({
+      startDate,
+      endDate,
+    });
   }
 
   @Get('versions/current')

--- a/src/documentation/documentation.module.ts
+++ b/src/documentation/documentation.module.ts
@@ -10,6 +10,7 @@ import { ApiKeyService } from './services/api-key.service';
 import { SdkGeneratorService } from './services/sdk-generator.service';
 import { ApiAnalyticsService } from './services/api-analytics.service';
 import { ApiVersioningService } from './services/api-versioning.service';
+import { ApiVersionGuard } from './guards/api-version.guard';
 import { ApiExplorerService } from './services/api-explorer.service';
 import { ApiTestingService } from './services/api-testing.service';
 import { DocumentationController } from './controllers/documentation.controller';
@@ -33,6 +34,7 @@ import { User } from '../auth/entities/user.entity';
     ApiTestingService,
     ApiKeyGuard,
     ApiUsageInterceptor,
+    ApiVersionGuard,
   ],
   exports: [
     ApiKeyService,

--- a/src/documentation/dto/analytics.dto.ts
+++ b/src/documentation/dto/analytics.dto.ts
@@ -47,6 +47,10 @@ export class ApiAnalyticsResponseDto {
     errorCount: number;
   }>;
   requestsByStatus: Record<string, number>;
+  requestsByVersion: Array<{
+    version: string;
+    count: number;
+  }>;
   requestsOverTime: Array<{
     timestamp: Date;
     count: number;

--- a/src/documentation/entities/api-usage.entity.ts
+++ b/src/documentation/entities/api-usage.entity.ts
@@ -21,6 +21,7 @@ export enum HttpMethod {
 @Index(['apiKeyId', 'timestamp'])
 @Index(['endpoint', 'method', 'timestamp'])
 @Index(['statusCode', 'timestamp'])
+@Index(['version', 'endpoint', 'method', 'timestamp'])
 export class ApiUsage {
   @PrimaryGeneratedColumn('uuid')
   id: string;
@@ -61,6 +62,9 @@ export class ApiUsage {
 
   @Column({ type: 'jsonb', nullable: true })
   requestHeaders?: Record<string, any>;
+
+  @Column({ nullable: true })
+  version?: string;
 
   @Column({ type: 'jsonb', nullable: true })
   errorDetails?: {

--- a/src/documentation/guards/api-key.guard.ts
+++ b/src/documentation/guards/api-key.guard.ts
@@ -54,6 +54,7 @@ export class ApiKeyGuard implements CanActivate {
             userAgent: request.headers['user-agent'],
             queryParams: request.query,
             requestHeaders: request.headers,
+            version: request.apiVersion,
           })
           .catch(() => {
             // Ignore tracking errors

--- a/src/documentation/guards/api-version.guard.ts
+++ b/src/documentation/guards/api-version.guard.ts
@@ -1,0 +1,76 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  BadRequestException,
+  GoneException,
+  Logger,
+} from '@nestjs/common';
+import { ApiVersioningService } from '../services/api-versioning.service';
+import { VersionStatus } from '../entities/api-version.entity';
+
+@Injectable()
+export class ApiVersionGuard implements CanActivate {
+  private readonly logger = new Logger(ApiVersionGuard.name);
+
+  constructor(private versioningService: ApiVersioningService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest();
+    const response = context.switchToHttp().getResponse();
+
+    const headerVersion =
+      (request.headers['x-api-version'] || request.headers['api-version'] || '')
+        .toString()
+        .trim();
+
+    let version = headerVersion || '';
+
+    if (!version) {
+      const uriMatch = request.url?.match(/\/v(\d+(?:\.\d+)?)(?=\/|$)/i);
+      if (uriMatch) {
+        version = `v${uriMatch[1]}`;
+      }
+    }
+
+    if (!version) {
+      version = 'v1';
+    }
+
+    if (!version.startsWith('v')) {
+      version = `v${version}`;
+    }
+
+    const versionEntity = await this.versioningService.getVersionByName(version);
+
+    if (!versionEntity) {
+      this.logger.warn(`Unsupported API version requested: ${version}`);
+      throw new BadRequestException(`Unsupported API version: ${version}`);
+    }
+
+    if (
+      versionEntity.status === VersionStatus.DEPRECATED ||
+      versionEntity.status === VersionStatus.SUNSET
+    ) {
+      this.logger.warn(`Deprecated or sunset API version accessed: ${version}`);
+      throw new GoneException(
+        `API version ${version} is ${versionEntity.status}. Migrate to current version.
+` +
+          `See /api/v1/documentation/versions for version details.`,
+      );
+    }
+
+    // Attach version metadata for analytics and endpoint tracking
+    request.apiVersion = version;
+    response.setHeader('X-API-Version', version);
+    response.setHeader('X-API-Version-Status', versionEntity.status);
+    if (versionEntity.deprecationDate) {
+      response.setHeader('X-API-Version-Deprecated-At', versionEntity.deprecationDate.toISOString());
+    }
+    if (versionEntity.sunsetDate) {
+      response.setHeader('X-API-Version-Sunset-At', versionEntity.sunsetDate.toISOString());
+    }
+
+    return true;
+  }
+}

--- a/src/documentation/interceptors/api-usage.interceptor.ts
+++ b/src/documentation/interceptors/api-usage.interceptor.ts
@@ -31,6 +31,7 @@ export class ApiUsageInterceptor implements NestInterceptor {
                 queryParams: request.query,
                 requestHeaders: request.headers,
                 responseSize: JSON.stringify(data).length,
+                version: request.apiVersion,
               })
               .catch(() => {
                 // Ignore tracking errors
@@ -50,6 +51,7 @@ export class ApiUsageInterceptor implements NestInterceptor {
                   message: error.message,
                   code: error.code,
                 },
+                version: request.apiVersion,
               })
               .catch(() => {
                 // Ignore tracking errors

--- a/src/documentation/services/api-analytics.service.ts
+++ b/src/documentation/services/api-analytics.service.ts
@@ -33,6 +33,7 @@ export class ApiAnalyticsService {
       queryParams?: Record<string, any>;
       requestHeaders?: Record<string, any>;
       errorDetails?: any;
+      version?: string;
     },
   ): Promise<void> {
     try {
@@ -112,6 +113,18 @@ export class ApiAnalyticsService {
       requestsByStatus[status.toString()] = count;
     });
 
+    // Requests by API version
+    const versionMap = new Map<string, number>();
+    usages.forEach((usage) => {
+      const versionKey = usage.version || 'v1';
+      versionMap.set(versionKey, (versionMap.get(versionKey) || 0) + 1);
+    });
+
+    const requestsByVersion = Array.from(versionMap.entries()).map(([version, count]) => ({
+      version,
+      count,
+    }));
+
     // Requests over time (hourly aggregation)
     const timeMap = new Map<string, { count: number; totalTime: number }>();
     usages.forEach((usage) => {
@@ -159,6 +172,7 @@ export class ApiAnalyticsService {
       errorRate: Math.round(errorRate * 100) / 100,
       requestsByEndpoint,
       requestsByStatus,
+      requestsByVersion,
       requestsOverTime,
       topApiKeys,
     };

--- a/src/documentation/services/api-versioning.service.ts
+++ b/src/documentation/services/api-versioning.service.ts
@@ -44,6 +44,24 @@ export class ApiVersioningService {
   }
 
   /**
+   * Get version by version string (v1, v2, etc.)
+   */
+  async getVersionByName(version: string): Promise<ApiVersion | null> {
+    return this.versionRepository.findOne({
+      where: { version },
+      relations: ['endpoints'],
+    });
+  }
+
+  /**
+   * Get version status by version string
+   */
+  async getVersionStatus(version: string): Promise<VersionStatus | null> {
+    const versionEntity = await this.getVersionByName(version);
+    return versionEntity ? versionEntity.status : null;
+  }
+
+  /**
    * Create new version
    */
   async createVersion(

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,6 @@
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
+import { VersioningType } from '@nestjs/common';
 import helmet from 'helmet';
 import { SwaggerModule, DocumentBuilder } from '@nestjs/swagger';
 import { AllExceptionsFilter } from './common/filters/all-exceptions.filter';
@@ -12,6 +13,7 @@ import { Logger } from 'winston';
 import * as compression from 'compression';
 import { PerformanceInterceptor } from './common/interceptors/performance.interceptor';
 import { json, urlencoded } from 'express';
+import { ApiVersionGuard } from './documentation/guards/api-version.guard';
 
 async function bootstrap() {
   // Sentry: only init when a valid DSN is set (skip placeholder or empty)
@@ -54,6 +56,7 @@ async function bootstrap() {
 
   app.useGlobalFilters(new AllExceptionsFilter());
 
+  app.useGlobalGuards(app.get(ApiVersionGuard));
   app.useGlobalInterceptors(new PerformanceInterceptor());
   // CORS configuration
   // app.enableCors({
@@ -71,8 +74,13 @@ async function bootstrap() {
     1,
   );
 
-  // API prefix
+  // API prefix with versioning support
   app.setGlobalPrefix('api');
+  app.enableVersioning({
+    type: VersioningType.URI,
+    defaultVersion: '1',
+    prefix: 'v',
+  });
 
   // Swagger documentation
   const config = new DocumentBuilder()

--- a/src/migrations/1710000000000-CreateDocumentationTables.ts
+++ b/src/migrations/1710000000000-CreateDocumentationTables.ts
@@ -195,6 +195,11 @@ export class CreateDocumentationTables1710000000000 implements MigrationInterfac
             isNullable: true,
           },
           {
+            name: 'version',
+            type: 'varchar',
+            isNullable: true,
+          },
+          {
             name: 'errorDetails',
             type: 'jsonb',
             isNullable: true,
@@ -222,6 +227,14 @@ export class CreateDocumentationTables1710000000000 implements MigrationInterfac
       new TableIndex({
         name: 'IDX_api_usage_endpoint_method_timestamp',
         columnNames: ['endpoint', 'method', 'timestamp'],
+      }),
+    );
+
+    await queryRunner.createIndex(
+      'api_usage',
+      new TableIndex({
+        name: 'IDX_api_usage_version_endpoint_method_timestamp',
+        columnNames: ['version', 'endpoint', 'method', 'timestamp'],
       }),
     );
 


### PR DESCRIPTION
Closes: #621 

## Title
Implement API versioning strategy + deprecation/migration + monitoring

## Description
- Global versioning enabled in `src/main.ts`: URI-based versioning (`/api/v1/...`), default `v1`.
- Added `ApiVersionGuard` to enforce supported, deprecated, and sunset version policy.
- Added versioning endpoints in `src/documentation/controllers/documentation.controller.ts`:
  - `GET /documentation/versions`
  - `POST /documentation/versions`
  - `PUT /documentation/versions/:id/deprecate`
  - `GET /documentation/versions/:id/status`
  - `GET /documentation/versions/current`
  - `GET /documentation/versions/migration/:from/:to`
  - `GET /documentation/versions/analytics`
  - Existing deprecations: `GET /documentation/endpoints/deprecated`
- Added version-aware usage tracking:
  - `ApiUsage.version` in `src/documentation/entities/api-usage.entity.ts`
  - `requestsByVersion` in analytics response
  - `version` attribute set by guard in `ApiUsageInterceptor` and `ApiKeyGuard`
- Added DB migration index and column for version usage tracking in `src/migrations/1710000000000-CreateDocumentationTables.ts`

## Impact
- enables backward compatibility and controlled version depreciation
- supports version migration guidance and monitoring
- ensures API consumers can detect and adjust for deprecation

## Notes
- local environment fix required: run `npm install` (TS error `Cannot find module '@nestjs/common'` due missing dependencies in `node_modules`).
- commit: `46bfb865`
- branch: `fix/missingAPIStrategy`
