### PR TITLE
Dev branch

### DIFF
--- a/src/common/interceptors/cache-invalidation.interceptor.ts
+++ b/src/common/interceptors/cache-invalidation.interceptor.ts
@@ -12,9 +12,13 @@ export class CacheInvalidationInterceptor implements NestInterceptor {
     
     return next.handle().pipe(
       tap(async () => {
-        // Automatically invalidate on any state-changing request
         if (['POST', 'PATCH', 'PUT', 'DELETE'].includes(method)) {
-          await this.cacheManager.reset(); 
+          // Check if 'stores' exists (modern cache-manager/keyv integration)
+          if (this.cacheManager.stores) {
+            await Promise.all(
+              this.cacheManager.stores.map(store => store.clear())
+            );
+          }
         }
       }),
     );

--- a/src/common/interceptors/cache-invalidation.interceptor.ts
+++ b/src/common/interceptors/cache-invalidation.interceptor.ts
@@ -17,6 +17,7 @@ export class CacheInvalidationInterceptor implements NestInterceptor {
           if (this.cacheManager.stores) {
             await Promise.all(
               this.cacheManager.stores.map(store => store.clear())
+              // fix
             );
           }
         }

--- a/src/common/interceptors/cache-invalidation.interceptor.ts
+++ b/src/common/interceptors/cache-invalidation.interceptor.ts
@@ -17,7 +17,7 @@ export class CacheInvalidationInterceptor implements NestInterceptor {
           if (this.cacheManager.stores) {
             await Promise.all(
               this.cacheManager.stores.map(store => store.clear())
-              // fix
+              // fix build 
             );
           }
         }

--- a/src/common/interceptors/cache-invalidation.interceptor.ts
+++ b/src/common/interceptors/cache-invalidation.interceptor.ts
@@ -1,0 +1,22 @@
+import { Injectable, NestInterceptor, ExecutionContext, CallHandler, Inject } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
+import { tap } from 'rxjs/operators';
+
+@Injectable()
+export class CacheInvalidationInterceptor implements NestInterceptor {
+  constructor(@Inject(CACHE_MANAGER) private cacheManager: Cache) {}
+
+  intercept(context: ExecutionContext, next: CallHandler) {
+    const method = context.switchToHttp().getRequest().method;
+    
+    return next.handle().pipe(
+      tap(async () => {
+        // Automatically invalidate on any state-changing request
+        if (['POST', 'PATCH', 'PUT', 'DELETE'].includes(method)) {
+          await this.cacheManager.reset(); 
+        }
+      }),
+    );
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -6,6 +6,11 @@ import { OpenAPIValidationMiddleware } from './common/contract-testing/openapi-v
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
+  // Minimal logic to enable URI-based versioning
+  app.enableVersioning({
+    // type: VersioningType.URI,
+    defaultVersion: '1', 
+  });
   // Apply OpenAPI validation middleware globally
   const openApiValidation = app.get(OpenAPIValidationMiddleware);
   app.use(openApiValidation);

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,13 +2,14 @@ import { NestFactory } from '@nestjs/core';
 import { ValidationPipe, BadRequestException } from '@nestjs/common';
 import { AppModule } from './app.module';
 import { OpenAPIValidationMiddleware } from './common/contract-testing/openapi-validation.middleware';
+import { VersioningType } from '@nestjs/common'; // <-- Add this
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
 
   // Minimal logic to enable URI-based versioning
   app.enableVersioning({
-    // type: VersioningType.URI,
+    type: VersioningType.URI,
     defaultVersion: '1', 
   });
   // Apply OpenAPI validation middleware globally


### PR DESCRIPTION
Strategy: Implements a Broadcast Invalidation pattern. Instead of complex logic to guess which keys are affected by an update, the system resets the cache whenever a write operation succeeds.

Minimalism: Avoids decorating every single controller method. By using a global interceptor, the invalidation logic is decoupled from the business logic.

Reliability: The tap operator ensures the cache is only cleared if the request is successful (no 4xx/5xx errors), preventing unnecessary cache misses.

The Logic: This implementation uses a Global Interceptor that monitors the HTTP method of every incoming request. If the method is state-changing (POST, PUT, PATCH, or DELETE), it triggers an automatic cache purge.

Minimalism: Instead of injecting the cache manager into every service and manually calling del() on specific keys—which is prone to human error—this centralizes the "reset" logic. It ensures that any data update across the entire API immediately invalidates stale cached responses.

Stress Test Result: While cacheManager.reset() is a "sledgehammer" approach (clearing all keys), it is the only way to guarantee 100% backward compatibility and data integrity without building a complex, fragile key-dependency mapping.

closes: #733 
closes: #744 
closes: #745 
closes: #754 