### PR TITLE
feat(security): add security headers middleware

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -12,6 +12,7 @@ import { SecurityModule } from './security/security.module';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { RequestIdMiddleware } from './common/middleware/request-id.middleware';
+import { SecurityHeadersMiddleware } from './security/security-headers.middleware';
 
 @Module({
   imports: [
@@ -47,6 +48,8 @@ import { RequestIdMiddleware } from './common/middleware/request-id.middleware';
 })
 export class AppModule implements NestModule {
   configure(consumer: MiddlewareConsumer) {
+    // Security headers applied first, before any route logic
+    consumer.apply(SecurityHeadersMiddleware).forRoutes('*');
     consumer.apply(RequestIdMiddleware).forRoutes('*');
   }
 }

--- a/src/security/security-headers.middleware.ts
+++ b/src/security/security-headers.middleware.ts
@@ -1,0 +1,93 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import helmet from 'helmet';
+
+/**
+ * SecurityHeadersMiddleware
+ *
+ * Applies HTTP security headers to every response using helmet.
+ * Covers: X-Frame-Options, Content-Security-Policy, HSTS, X-Content-Type-Options,
+ * and several additional hardening headers.
+ */
+@Injectable()
+export class SecurityHeadersMiddleware implements NestMiddleware {
+  private readonly helmetMiddleware: ReturnType<typeof helmet>;
+
+  constructor() {
+    const isProduction = process.env.NODE_ENV === 'production';
+
+    this.helmetMiddleware = helmet({
+      // X-Content-Type-Options: nosniff
+      // Prevents browsers from MIME-sniffing a response away from the declared content-type.
+      contentTypeOptions: true,
+
+      // X-Frame-Options: DENY
+      // Prevents the page from being embedded in iframes — protects against clickjacking.
+      frameguard: { action: 'deny' },
+
+      // Strict-Transport-Security (HSTS)
+      // Forces HTTPS for 1 year, includes subdomains, and opts into HSTS preload list.
+      // Only enforced in production to avoid breaking local HTTP dev flows.
+      hsts: isProduction
+        ? {
+            maxAge: 31536000, // 1 year in seconds
+            includeSubDomains: true,
+            preload: true,
+          }
+        : false,
+
+      // Content-Security-Policy (CSP)
+      // Restricts which resources the browser is allowed to load.
+      // Tighten the directives below to match your actual frontend/CDN origins.
+      contentSecurityPolicy: {
+        directives: {
+          defaultSrc: ["'self'"],
+          scriptSrc: ["'self'"],
+          styleSrc: ["'self'", "'unsafe-inline'"], // unsafe-inline needed for many UI frameworks; remove when possible
+          imgSrc: ["'self'", 'data:', 'https:'],
+          fontSrc: ["'self'", 'https:', 'data:'],
+          connectSrc: ["'self'"],
+          objectSrc: ["'none'"],
+          mediaSrc: ["'self'"],
+          frameSrc: ["'none'"],
+          frameAncestors: ["'none'"], // Reinforces X-Frame-Options at the CSP level
+          baseUri: ["'self'"],
+          formAction: ["'self'"],
+          upgradeInsecureRequests: isProduction ? [] : null, // Only in production
+        },
+      },
+
+      // X-XSS-Protection: disabled intentionally — modern browsers ignore it and
+      // it can introduce vulnerabilities in older IE. CSP is the correct mitigation.
+      xssFilter: false,
+
+      // Referrer-Policy: no-referrer
+      // Prevents leaking the URL in the Referer header to third parties.
+      referrerPolicy: { policy: 'no-referrer' },
+
+      // X-Permitted-Cross-Domain-Policies: none
+      // Disallows Adobe Flash/PDF cross-domain requests.
+      permittedCrossDomainPolicies: false,
+
+      // X-DNS-Prefetch-Control: off
+      // Disables browser DNS prefetching to reduce privacy leakage.
+      dnsPrefetchControl: { allow: false },
+
+      // X-Download-Options: noopen (IE-specific, harmless elsewhere)
+      ieNoOpen: true,
+
+      // Remove X-Powered-By header to avoid fingerprinting the server.
+      hidePoweredBy: true,
+
+      // Cross-Origin-Opener-Policy
+      crossOriginOpenerPolicy: { policy: 'same-origin' },
+
+      // Cross-Origin-Resource-Policy
+      crossOriginResourcePolicy: { policy: 'same-origin' },
+    });
+  }
+
+  use(req: Request, res: Response, next: NextFunction): void {
+    this.helmetMiddleware(req, res, next);
+  }
+}

--- a/src/security/security.module.ts
+++ b/src/security/security.module.ts
@@ -2,9 +2,10 @@ import { Module } from '@nestjs/common';
 import { ApiKeyService } from './api-key.service';
 import { IpWhitelistGuard } from './ip-whitelist.guard';
 import { RequestSigningService } from './request-signing.service';
+import { SecurityHeadersMiddleware } from './security-headers.middleware';
 
 @Module({
-  providers: [ApiKeyService, RequestSigningService, IpWhitelistGuard],
-  exports: [ApiKeyService, RequestSigningService, IpWhitelistGuard],
+  providers: [ApiKeyService, RequestSigningService, IpWhitelistGuard, SecurityHeadersMiddleware],
+  exports: [ApiKeyService, RequestSigningService, IpWhitelistGuard, SecurityHeadersMiddleware],
 })
 export class SecurityModule {}


### PR DESCRIPTION
Closes #821
## Summary
Adds HTTP security headers to all responses via a dedicated NestJS middleware wrapping helmet.

## Changes
- New `SecurityHeadersMiddleware` in `src/security/`
- Registered in `SecurityModule` and applied globally as first middleware in `AppModule`

## Headers added
- `X-Frame-Options: DENY` — clickjacking protection
- `X-Content-Type-Options: nosniff` — blocks MIME sniffing
- `Strict-Transport-Security` — HSTS with 1yr max-age, includeSubDomains, preload (production only)
- `Content-Security-Policy` — strict directives, upgrade-insecure-requests in production
- `Referrer-Policy: no-referrer`
- `Cross-Origin-Opener-Policy: same-origin`
- `Cross-Origin-Resource-Policy: same-origin`


