### PR TITLE
feat: Add query caching, Redis pooling, request debouncing, and image optimization

### DIFF
--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -16,6 +16,10 @@ import { AppService } from './app.service';
 import { CommonModule } from './common/common.module';
 import { RequestIdMiddleware } from './common/middleware/request-id.middleware';
 import { CertificatePinningMiddleware } from './common/middleware/certificate-pinning.middleware';
+import { AppCacheModule } from './common/cache/cache.module';
+import { RedisPoolModule } from './common/redis/redis-pool.module';
+import { DebounceModule } from './common/debounce/debounce.module';
+import { ImageProcessingModule } from './common/image/image-processing.module';
 
 @Module({
   imports: [
@@ -46,6 +50,10 @@ import { CertificatePinningMiddleware } from './common/middleware/certificate-pi
     GdprModule,
     ContractTestingModule,
     CommonModule,
+    AppCacheModule,
+    RedisPoolModule,
+    DebounceModule,
+    ImageProcessingModule,
   ],
   controllers: [AppController],
   providers: [

--- a/src/common/cache/cache.module.ts
+++ b/src/common/cache/cache.module.ts
@@ -1,0 +1,21 @@
+import { Global, Module } from '@nestjs/common';
+import { CacheModule } from '@nestjs/cache-manager';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import { QueryCacheService } from './query-cache.service';
+
+@Global()
+@Module({
+  imports: [
+    CacheModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        ttl: config.get<number>('CACHE_TTL_MS', 60_000),
+        max: config.get<number>('CACHE_MAX_ITEMS', 500),
+      }),
+    }),
+  ],
+  providers: [QueryCacheService],
+  exports: [QueryCacheService, CacheModule],
+})
+export class AppCacheModule {}

--- a/src/common/cache/query-cache.service.spec.ts
+++ b/src/common/cache/query-cache.service.spec.ts
@@ -1,0 +1,47 @@
+import { Test, TestingModule } from '@nestjs/testing';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { QueryCacheService } from './query-cache.service';
+
+describe('QueryCacheService', () => {
+  let service: QueryCacheService;
+  const store = new Map<string, unknown>();
+  const mockCache = {
+    get: jest.fn((key: string) => Promise.resolve(store.get(key))),
+    set: jest.fn((key: string, value: unknown) => { store.set(key, value); return Promise.resolve(); }),
+    del: jest.fn((key: string) => { store.delete(key); return Promise.resolve(); }),
+  };
+
+  beforeEach(async () => {
+    store.clear();
+    jest.clearAllMocks();
+    const module: TestingModule = await Test.createTestingModule({
+      providers: [
+        QueryCacheService,
+        { provide: CACHE_MANAGER, useValue: mockCache },
+      ],
+    }).compile();
+    service = module.get(QueryCacheService);
+  });
+
+  it('getOrSet calls factory on miss and caches result', async () => {
+    const factory = jest.fn().mockResolvedValue([{ id: '1' }]);
+    const result = await service.getOrSet('key1', factory);
+    expect(factory).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([{ id: '1' }]);
+    expect(mockCache.set).toHaveBeenCalledWith('key1', [{ id: '1' }], 60_000);
+  });
+
+  it('getOrSet returns cached value without calling factory', async () => {
+    store.set('key2', 'cached');
+    const factory = jest.fn();
+    const result = await service.getOrSet('key2', factory);
+    expect(factory).not.toHaveBeenCalled();
+    expect(result).toBe('cached');
+  });
+
+  it('del removes a key', async () => {
+    store.set('key3', 'value');
+    await service.del('key3');
+    expect(store.has('key3')).toBe(false);
+  });
+});

--- a/src/common/cache/query-cache.service.ts
+++ b/src/common/cache/query-cache.service.ts
@@ -1,0 +1,28 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
+
+@Injectable()
+export class QueryCacheService {
+  constructor(@Inject(CACHE_MANAGER) private readonly cache: Cache) {}
+
+  async get<T>(key: string): Promise<T | undefined> {
+    return this.cache.get<T>(key);
+  }
+
+  async set(key: string, value: unknown, ttlMs = 60_000): Promise<void> {
+    await this.cache.set(key, value, ttlMs);
+  }
+
+  async del(key: string): Promise<void> {
+    await this.cache.del(key);
+  }
+
+  async getOrSet<T>(key: string, factory: () => Promise<T>, ttlMs = 60_000): Promise<T> {
+    const cached = await this.cache.get<T>(key);
+    if (cached !== undefined && cached !== null) return cached;
+    const value = await factory();
+    await this.cache.set(key, value, ttlMs);
+    return value;
+  }
+}

--- a/src/common/debounce/debounce.decorator.ts
+++ b/src/common/debounce/debounce.decorator.ts
@@ -1,0 +1,11 @@
+import { SetMetadata } from '@nestjs/common';
+
+export const DEBOUNCE_KEY = 'debounce';
+
+/**
+ * Marks an endpoint for debounce protection.
+ * @param windowMs  Time window in ms during which duplicate requests are rejected (default 1000ms)
+ * @param keyBy     Request property used to identify the caller: 'ip' | 'user' (default 'ip')
+ */
+export const Debounce = (windowMs = 1_000, keyBy: 'ip' | 'user' = 'ip') =>
+  SetMetadata(DEBOUNCE_KEY, { windowMs, keyBy });

--- a/src/common/debounce/debounce.guard.spec.ts
+++ b/src/common/debounce/debounce.guard.spec.ts
@@ -1,0 +1,36 @@
+import { Reflector } from '@nestjs/core';
+import { ExecutionContext, HttpException } from '@nestjs/common';
+import { DebounceGuard } from './debounce.guard';
+import { DEBOUNCE_KEY } from './debounce.decorator';
+
+function makeContext(ip = '1.2.3.4', options?: { windowMs: number; keyBy: 'ip' | 'user' }) {
+  const reflector = new Reflector();
+  jest.spyOn(reflector, 'getAllAndOverride').mockReturnValue(options);
+  const guard = new DebounceGuard(reflector);
+  const ctx = {
+    getHandler: () => ({}),
+    getClass: () => ({}),
+    switchToHttp: () => ({
+      getRequest: () => ({ method: 'GET', route: { path: '/test' }, ip, user: null }),
+    }),
+  } as unknown as ExecutionContext;
+  return { guard, ctx };
+}
+
+describe('DebounceGuard', () => {
+  it('allows request when no debounce metadata', () => {
+    const { guard, ctx } = makeContext('1.2.3.4', undefined);
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('allows first request within window', () => {
+    const { guard, ctx } = makeContext('1.2.3.4', { windowMs: 1000, keyBy: 'ip' });
+    expect(guard.canActivate(ctx)).toBe(true);
+  });
+
+  it('blocks second request within window', () => {
+    const { guard, ctx } = makeContext('1.2.3.4', { windowMs: 5000, keyBy: 'ip' });
+    guard.canActivate(ctx);
+    expect(() => guard.canActivate(ctx)).toThrow(HttpException);
+  });
+});

--- a/src/common/debounce/debounce.guard.ts
+++ b/src/common/debounce/debounce.guard.ts
@@ -1,0 +1,58 @@
+import {
+  Injectable,
+  CanActivate,
+  ExecutionContext,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { Reflector } from '@nestjs/core';
+import { DEBOUNCE_KEY } from './debounce.decorator';
+
+interface DebounceOptions {
+  windowMs: number;
+  keyBy: 'ip' | 'user';
+}
+
+@Injectable()
+export class DebounceGuard implements CanActivate {
+  /** key → expiry timestamp */
+  private readonly store = new Map<string, number>();
+
+  constructor(private readonly reflector: Reflector) {}
+
+  canActivate(context: ExecutionContext): boolean {
+    const options = this.reflector.getAllAndOverride<DebounceOptions>(DEBOUNCE_KEY, [
+      context.getHandler(),
+      context.getClass(),
+    ]);
+
+    if (!options) return true;
+
+    const req = context.switchToHttp().getRequest();
+    const routeKey = `${req.method}:${req.route?.path ?? req.url}`;
+    const callerKey =
+      options.keyBy === 'user' ? (req.user?.id ?? req.ip) : req.ip;
+    const key = `${routeKey}:${callerKey}`;
+
+    const now = Date.now();
+    const expiry = this.store.get(key);
+
+    if (expiry && now < expiry) {
+      throw new HttpException(
+        { message: 'Too many requests, please slow down.', retryAfter: expiry - now },
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
+    }
+
+    this.store.set(key, now + options.windowMs);
+
+    // Cleanup expired entries periodically to avoid memory leaks
+    if (this.store.size > 10_000) {
+      for (const [k, exp] of this.store) {
+        if (now >= exp) this.store.delete(k);
+      }
+    }
+
+    return true;
+  }
+}

--- a/src/common/debounce/debounce.module.ts
+++ b/src/common/debounce/debounce.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { DebounceGuard } from './debounce.guard';
+
+@Global()
+@Module({
+  providers: [DebounceGuard],
+  exports: [DebounceGuard],
+})
+export class DebounceModule {}

--- a/src/common/image/image-processing.module.ts
+++ b/src/common/image/image-processing.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { ImageProcessingService } from './image-processing.service';
+
+@Global()
+@Module({
+  providers: [ImageProcessingService],
+  exports: [ImageProcessingService],
+})
+export class ImageProcessingModule {}

--- a/src/common/image/image-processing.service.ts
+++ b/src/common/image/image-processing.service.ts
@@ -1,0 +1,67 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+import sharp from 'sharp';
+
+export interface ImageProcessingOptions {
+  width?: number;
+  height?: number;
+  quality?: number;
+  format?: 'jpeg' | 'png' | 'webp' | 'avif';
+}
+
+export interface ProcessedImage {
+  buffer: Buffer;
+  mimeType: string;
+  size: number;
+}
+
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'image/gif', 'image/avif'];
+const MAX_SIZE_BYTES = 10 * 1024 * 1024; // 10 MB
+
+@Injectable()
+export class ImageProcessingService {
+  async process(
+    input: Buffer,
+    mimeType: string,
+    options: ImageProcessingOptions = {},
+  ): Promise<ProcessedImage> {
+    if (!ALLOWED_MIME_TYPES.includes(mimeType)) {
+      throw new BadRequestException(`Unsupported image type: ${mimeType}`);
+    }
+    if (input.length > MAX_SIZE_BYTES) {
+      throw new BadRequestException('Image exceeds maximum allowed size of 10 MB');
+    }
+
+    const { width = 1920, height, quality = 80, format = 'webp' } = options;
+
+    const pipeline = sharp(input).resize(width, height, {
+      fit: 'inside',
+      withoutEnlargement: true,
+    });
+
+    let buffer: Buffer;
+    switch (format) {
+      case 'jpeg':
+        buffer = await pipeline.jpeg({ quality, mozjpeg: true }).toBuffer();
+        break;
+      case 'png':
+        buffer = await pipeline.png({ compressionLevel: 9 }).toBuffer();
+        break;
+      case 'avif':
+        buffer = await pipeline.avif({ quality }).toBuffer();
+        break;
+      case 'webp':
+      default:
+        buffer = await pipeline.webp({ quality }).toBuffer();
+        break;
+    }
+
+    return { buffer, mimeType: `image/${format}`, size: buffer.length };
+  }
+
+  async generateThumbnail(input: Buffer, size = 200): Promise<Buffer> {
+    return sharp(input)
+      .resize(size, size, { fit: 'cover' })
+      .webp({ quality: 70 })
+      .toBuffer();
+  }
+}

--- a/src/common/redis/redis-pool.module.ts
+++ b/src/common/redis/redis-pool.module.ts
@@ -1,0 +1,9 @@
+import { Global, Module } from '@nestjs/common';
+import { RedisPoolService } from './redis-pool.service';
+
+@Global()
+@Module({
+  providers: [RedisPoolService],
+  exports: [RedisPoolService],
+})
+export class RedisPoolModule {}

--- a/src/common/redis/redis-pool.service.ts
+++ b/src/common/redis/redis-pool.service.ts
@@ -1,0 +1,41 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import Redis, { RedisOptions } from 'ioredis';
+
+@Injectable()
+export class RedisPoolService {
+  private readonly client: Redis;
+
+  constructor(private readonly config: ConfigService) {
+    const options: RedisOptions = {
+      host: this.config.get<string>('REDIS_HOST', 'localhost'),
+      port: this.config.get<number>('REDIS_PORT', 6379),
+      password: this.config.get<string>('REDIS_PASSWORD'),
+      db: this.config.get<number>('REDIS_DB', 0),
+      // Connection pool settings
+      maxRetriesPerRequest: 3,
+      enableReadyCheck: true,
+      lazyConnect: true,
+      // Keep-alive to reuse connections
+      keepAlive: 10_000,
+      connectTimeout: 10_000,
+      commandTimeout: 5_000,
+      // Reconnect strategy
+      retryStrategy: (times: number) => Math.min(times * 100, 3_000),
+    };
+
+    this.client = new Redis(options);
+  }
+
+  getClient(): Redis {
+    return this.client;
+  }
+
+  async ping(): Promise<string> {
+    return this.client.ping();
+  }
+
+  async onModuleDestroy(): Promise<void> {
+    await this.client.quit();
+  }
+}

--- a/src/course/course.service.ts
+++ b/src/course/course.service.ts
@@ -2,26 +2,30 @@ import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Course } from './entities/course.entity';
+import { QueryCacheService } from '../common/cache/query-cache.service';
 
 @Injectable()
 export class CourseService {
   constructor(
     @InjectRepository(Course)
     private readonly courseRepository: Repository<Course>,
+    private readonly queryCache: QueryCacheService,
   ) {}
 
   async findAll(category?: string, difficulty?: string): Promise<Course[]> {
-    const where: any = {};
-    if (category) {
-      where.category = category;
-    }
-    if (difficulty) {
-      where.difficulty = difficulty;
-    }
-    return this.courseRepository.find({ where });
+    const key = `courses:all:${category ?? ''}:${difficulty ?? ''}`;
+    return this.queryCache.getOrSet(key, async () => {
+      const where: Record<string, string> = {};
+      if (category) where.category = category;
+      if (difficulty) where.difficulty = difficulty;
+      return this.courseRepository.find({ where });
+    });
   }
 
   async findOne(id: string): Promise<Course | null> {
-    return this.courseRepository.findOne({ where: { id } });
+    const key = `courses:one:${id}`;
+    return this.queryCache.getOrSet(key, () =>
+      this.courseRepository.findOne({ where: { id } }),
+    );
   }
 }


### PR DESCRIPTION
## Summary

Resolves all 4 issues assigned to @dzekojohn4 in a single PR.

Closes #802
Closes #804
Closes #805
Closes #806

---

## Changes

### #802 – Add Database Query Caching
- **`src/common/cache/query-cache.service.ts`** – `QueryCacheService` with `get`, `set`, `del`, and `getOrSet` helpers backed by `@nestjs/cache-manager`.
- **`src/common/cache/cache.module.ts`** – `AppCacheModule` (global) registers `CacheModule` with configurable TTL/max via env vars (`CACHE_TTL_MS`, `CACHE_MAX_ITEMS`).
- **`src/course/course.service.ts`** – `findAll` and `findOne` now use `QueryCacheService.getOrSet` to cache DB results.

### #804 – Implement Connection Pooling for Redis
- **`src/common/redis/redis-pool.service.ts`** – `RedisPoolService` wraps `ioredis` with keep-alive, configurable retry strategy, connect/command timeouts, and lazy connect.
- **`src/common/redis/redis-pool.module.ts`** – `RedisPoolModule` (global) exports the service for injection anywhere.

### #805 – Add Request Debouncing
- **`src/common/debounce/debounce.decorator.ts`** – `@Debounce(windowMs, keyBy)` decorator to annotate endpoints.
- **`src/common/debounce/debounce.guard.ts`** – `DebounceGuard` (NestJS `CanActivate`) uses an in-memory sliding-window store; returns `429 Too Many Requests` with `retryAfter` on duplicate calls within the window.
- **`src/common/debounce/debounce.module.ts`** – `DebounceModule` (global) exports the guard.

### #806 – Optimize Image Processing
- **`src/common/image/image-processing.service.ts`** – `ImageProcessingService` uses `sharp` for resize-on-upload (WebP/JPEG/PNG/AVIF output), thumbnail generation, MIME-type validation, and 10 MB size guard.
- **`src/common/image/image-processing.module.ts`** – `ImageProcessingModule` (global) exports the service.

---

## Tests
- 6 new unit tests added (`query-cache.service.spec.ts`, `debounce.guard.spec.ts`) – all pass.
- TypeScript compiles cleanly (`tsc --noEmit` exits 0).
- `npm run build` passes.