### PR TITLE
perf: replace in-memory pagination with DB-level keyset queries

### DIFF
--- a/src/auth/services/auth.service.ts
+++ b/src/auth/services/auth.service.ts
@@ -300,7 +300,6 @@ export class AuthService {
     if (!user) {
       this.secureLogger.warn(`Password reset failed: User not found for email: ${email}`);
       throw new UserNotFoundException(email);
-      throw new NotFoundException('User not found');
     }
 
     const hashedToken = this.hashToken(resetToken);

--- a/src/course/application/use-cases/get-course.use-case.ts
+++ b/src/course/application/use-cases/get-course.use-case.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
 import { UseCase } from '../../../shared/application/use-case.base';
-import { ICourseRepository } from '../../domain/repositories/course-repository.interface';
+import { ICourseRepository, COURSE_REPOSITORY } from '../../domain/repositories/course-repository.interface';
 import { CourseNotFoundException } from '../../domain/exceptions/course-exceptions';
 
 /**
@@ -32,7 +32,7 @@ export class GetCourseResponse {
  */
 @Injectable()
 export class GetCourseUseCase extends UseCase<GetCourseRequest, GetCourseResponse> {
-  constructor(private readonly courseRepository: ICourseRepository) {
+  constructor(@Inject(COURSE_REPOSITORY) private readonly courseRepository: ICourseRepository) {
     super();
   }
 

--- a/src/course/application/use-cases/list-courses.use-case.ts
+++ b/src/course/application/use-cases/list-courses.use-case.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
 import { UseCase } from '../../../shared/application/use-case.base';
-import { ICourseRepository } from '../../domain/repositories/course-repository.interface';
+import { ICourseRepository, COURSE_REPOSITORY } from '../../domain/repositories/course-repository.interface';
 
 /**
  * List Courses Use Case Request
@@ -47,44 +47,26 @@ export class ListCoursesResponse {
  */
 @Injectable()
 export class ListCoursesUseCase extends UseCase<ListCoursesRequest, ListCoursesResponse> {
-  constructor(private readonly courseRepository: ICourseRepository) {
+  constructor(@Inject(COURSE_REPOSITORY) private readonly courseRepository: ICourseRepository) {
     super();
   }
 
   async execute(request: ListCoursesRequest): Promise<ListCoursesResponse> {
     const limit = request.limit || 20;
+    const { cursor } = request;
 
-    let courses = [];
-
+    let result;
     if (request.category && request.difficulty) {
-      courses = await this.courseRepository.findByCategoryAndDifficulty(
-        request.category,
-        request.difficulty,
-      );
+      result = await this.courseRepository.findByCategoryAndDifficulty(request.category, request.difficulty, limit, cursor);
     } else if (request.category) {
-      courses = await this.courseRepository.findByCategory(request.category);
+      result = await this.courseRepository.findByCategory(request.category, limit, cursor);
     } else if (request.difficulty) {
-      courses = await this.courseRepository.findByDifficulty(request.difficulty);
+      result = await this.courseRepository.findByDifficulty(request.difficulty, limit, cursor);
     } else {
-      courses = await this.courseRepository.findAll();
+      result = await this.courseRepository.findPaginated(limit, cursor);
     }
 
-    // Apply cursor-based pagination
-    let filteredCourses = courses;
-    if (request.cursor) {
-      const cursorIndex = courses.findIndex((c) => c.id === request.cursor);
-      if (cursorIndex !== -1) {
-        filteredCourses = courses.slice(cursorIndex + 1);
-      }
-    }
-
-    // Check if there are more results
-    const hasMore = filteredCourses.length > limit;
-
-    // Take only the requested limit
-    const paginatedCourses = hasMore ? filteredCourses.slice(0, limit) : filteredCourses;
-
-    const courseItems = paginatedCourses.map((course) => {
+    const courseItems = result.items.map((course) => {
       const primitives = course.toPrimitives();
       return new ListCourseItem(
         primitives.id,
@@ -98,10 +80,8 @@ export class ListCoursesUseCase extends UseCase<ListCoursesRequest, ListCoursesR
       );
     });
 
-    // Generate next cursor
-    const nextCursor =
-      hasMore && courseItems.length > 0 ? courseItems[courseItems.length - 1].id : null;
+    const nextCursor = result.hasMore && courseItems.length > 0 ? courseItems[courseItems.length - 1].id : null;
 
-    return new ListCoursesResponse(courseItems, nextCursor, hasMore);
+    return new ListCoursesResponse(courseItems, nextCursor, result.hasMore);
   }
 }

--- a/src/course/course.module.ts
+++ b/src/course/course.module.ts
@@ -3,11 +3,24 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { CourseController } from './course.controller';
 import { CourseService } from './course.service';
 import { Course } from './entities/course.entity';
+import { CoursePersistenceEntity } from './infrastructure/persistence/course-persistence.entity';
+import { CourseRepositoryImpl } from './infrastructure/repositories/course-repository.impl';
+import { CourseMapper } from './application/mappers/course.mapper';
+import { ListCoursesUseCase } from './application/use-cases/list-courses.use-case';
+import { GetCourseUseCase } from './application/use-cases/get-course.use-case';
+import { COURSE_REPOSITORY } from './domain/repositories/course-repository.interface';
+import { AppCacheModule } from '../common/cache/cache.module';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Course])],
+  imports: [TypeOrmModule.forFeature([Course, CoursePersistenceEntity]), AppCacheModule],
   controllers: [CourseController],
-  providers: [CourseService],
+  providers: [
+    CourseService,
+    CourseMapper,
+    { provide: COURSE_REPOSITORY, useClass: CourseRepositoryImpl },
+    ListCoursesUseCase,
+    GetCourseUseCase,
+  ],
   exports: [CourseService],
 })
 export class CourseModule {}

--- a/src/course/domain/repositories/course-repository.interface.ts
+++ b/src/course/domain/repositories/course-repository.interface.ts
@@ -1,33 +1,18 @@
 import { IRepository } from '../../../shared/domain/repositories/repository.interface';
 import { Course } from '../entities/course.entity';
 
-/**
- * Course Repository Interface
- * Extends the generic IRepository with Course-specific query methods
- */
+export const COURSE_REPOSITORY = 'ICourseRepository';
+
+export interface PaginatedResult<T> {
+  items: T[];
+  hasMore: boolean;
+}
+
 export interface ICourseRepository extends IRepository<Course> {
-  /**
-   * Find courses by category
-   */
-  findByCategory(category: string): Promise<Course[]>;
-
-  /**
-   * Find courses by difficulty level
-   */
-  findByDifficulty(difficulty: string): Promise<Course[]>;
-
-  /**
-   * Find courses by both category and difficulty
-   */
-  findByCategoryAndDifficulty(category: string, difficulty: string): Promise<Course[]>;
-
-  /**
-   * Find all active courses
-   */
+  findByCategory(category: string, limit: number, afterId?: string): Promise<PaginatedResult<Course>>;
+  findByDifficulty(difficulty: string, limit: number, afterId?: string): Promise<PaginatedResult<Course>>;
+  findByCategoryAndDifficulty(category: string, difficulty: string, limit: number, afterId?: string): Promise<PaginatedResult<Course>>;
   findAllActive(): Promise<Course[]>;
-
-  /**
-   * Search courses by title
-   */
   findByTitle(title: string): Promise<Course[]>;
+  findPaginated(limit: number, afterId?: string): Promise<PaginatedResult<Course>>;
 }

--- a/src/course/infrastructure/repositories/course-repository.impl.ts
+++ b/src/course/infrastructure/repositories/course-repository.impl.ts
@@ -1,16 +1,11 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
-import { ICourseRepository } from '../../domain/repositories/course-repository.interface';
+import { ICourseRepository, PaginatedResult } from '../../domain/repositories/course-repository.interface';
 import { Course } from '../../domain/entities/course.entity';
 import { CoursePersistenceEntity } from '../persistence/course-persistence.entity';
 import { CourseMapper } from '../../application/mappers/course.mapper';
 
-/**
- * Course Repository Implementation
- * Implements the ICourseRepository interface using TypeORM
- * Handles all database operations for Course entities
- */
 @Injectable()
 export class CourseRepositoryImpl implements ICourseRepository {
   constructor(
@@ -27,37 +22,84 @@ export class CourseRepositoryImpl implements ICourseRepository {
 
   async findById(id: string): Promise<Course | null> {
     const entity = await this.typeOrmRepository.findOne({ where: { id } });
-    if (!entity) {
-      return null;
-    }
-    return this.courseMapper.toDomain(entity);
+    return entity ? this.courseMapper.toDomain(entity) : null;
   }
 
   async findAll(): Promise<Course[]> {
-    const entities = await this.typeOrmRepository.find();
-    return entities.map((entity) => this.courseMapper.toDomain(entity));
+    const entities = await this.typeOrmRepository.find({ take: 1000 });
+    return entities.map((e) => this.courseMapper.toDomain(e));
   }
 
-  async findByCategory(category: string): Promise<Course[]> {
-    const entities = await this.typeOrmRepository.find({ where: { category } });
-    return entities.map((entity) => this.courseMapper.toDomain(entity));
+  async findPaginated(limit: number, afterId?: string): Promise<PaginatedResult<Course>> {
+    const qb = this.typeOrmRepository
+      .createQueryBuilder('course')
+      .orderBy('course.id', 'ASC')
+      .take(limit + 1);
+
+    if (afterId) {
+      qb.where('course.id > :afterId', { afterId });
+    }
+
+    const entities = await qb.getMany();
+    const hasMore = entities.length > limit;
+    const items = entities.slice(0, limit).map((e) => this.courseMapper.toDomain(e));
+    return { items, hasMore };
   }
 
-  async findByDifficulty(difficulty: string): Promise<Course[]> {
-    const entities = await this.typeOrmRepository.find({ where: { difficulty } });
-    return entities.map((entity) => this.courseMapper.toDomain(entity));
+  async findByCategory(category: string, limit: number, afterId?: string): Promise<PaginatedResult<Course>> {
+    const qb = this.typeOrmRepository
+      .createQueryBuilder('course')
+      .where('course.category = :category', { category })
+      .orderBy('course.id', 'ASC')
+      .take(limit + 1);
+
+    if (afterId) {
+      qb.andWhere('course.id > :afterId', { afterId });
+    }
+
+    const entities = await qb.getMany();
+    const hasMore = entities.length > limit;
+    const items = entities.slice(0, limit).map((e) => this.courseMapper.toDomain(e));
+    return { items, hasMore };
   }
 
-  async findByCategoryAndDifficulty(category: string, difficulty: string): Promise<Course[]> {
-    const entities = await this.typeOrmRepository.find({
-      where: { category, difficulty },
-    });
-    return entities.map((entity) => this.courseMapper.toDomain(entity));
+  async findByDifficulty(difficulty: string, limit: number, afterId?: string): Promise<PaginatedResult<Course>> {
+    const qb = this.typeOrmRepository
+      .createQueryBuilder('course')
+      .where('course.difficulty = :difficulty', { difficulty })
+      .orderBy('course.id', 'ASC')
+      .take(limit + 1);
+
+    if (afterId) {
+      qb.andWhere('course.id > :afterId', { afterId });
+    }
+
+    const entities = await qb.getMany();
+    const hasMore = entities.length > limit;
+    const items = entities.slice(0, limit).map((e) => this.courseMapper.toDomain(e));
+    return { items, hasMore };
+  }
+
+  async findByCategoryAndDifficulty(category: string, difficulty: string, limit: number, afterId?: string): Promise<PaginatedResult<Course>> {
+    const qb = this.typeOrmRepository
+      .createQueryBuilder('course')
+      .where('course.category = :category AND course.difficulty = :difficulty', { category, difficulty })
+      .orderBy('course.id', 'ASC')
+      .take(limit + 1);
+
+    if (afterId) {
+      qb.andWhere('course.id > :afterId', { afterId });
+    }
+
+    const entities = await qb.getMany();
+    const hasMore = entities.length > limit;
+    const items = entities.slice(0, limit).map((e) => this.courseMapper.toDomain(e));
+    return { items, hasMore };
   }
 
   async findAllActive(): Promise<Course[]> {
     const entities = await this.typeOrmRepository.find({ where: { isActive: true } });
-    return entities.map((entity) => this.courseMapper.toDomain(entity));
+    return entities.map((e) => this.courseMapper.toDomain(e));
   }
 
   async findByTitle(title: string): Promise<Course[]> {
@@ -65,7 +107,7 @@ export class CourseRepositoryImpl implements ICourseRepository {
       .createQueryBuilder('course')
       .where('course.title ILIKE :title', { title: `%${title}%` })
       .getMany();
-    return entities.map((entity) => this.courseMapper.toDomain(entity));
+    return entities.map((e) => this.courseMapper.toDomain(e));
   }
 
   async delete(id: string): Promise<boolean> {

--- a/src/user/application/use-cases/get-user.use-case.ts
+++ b/src/user/application/use-cases/get-user.use-case.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
 import { UseCase } from '../../../shared/application/use-case.base';
-import { IUserRepository } from '../../domain/repositories/user-repository.interface';
+import { IUserRepository, USER_REPOSITORY } from '../../domain/repositories/user-repository.interface';
 import { UserNotFoundException } from '../../domain/exceptions/user-exceptions';
 
 /**
@@ -32,7 +32,7 @@ export class GetUserResponse {
  */
 @Injectable()
 export class GetUserUseCase extends UseCase<GetUserRequest, GetUserResponse> {
-  constructor(private readonly userRepository: IUserRepository) {
+  constructor(@Inject(USER_REPOSITORY) private readonly userRepository: IUserRepository) {
     super();
   }
 

--- a/src/user/application/use-cases/list-users.use-case.ts
+++ b/src/user/application/use-cases/list-users.use-case.ts
@@ -1,6 +1,6 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
 import { UseCase } from '../../../shared/application/use-case.base';
-import { IUserRepository } from '../../domain/repositories/user-repository.interface';
+import { IUserRepository, USER_REPOSITORY } from '../../domain/repositories/user-repository.interface';
 
 /**
  * List Users Use Case Request
@@ -46,37 +46,18 @@ export class ListUsersResponse {
  */
 @Injectable()
 export class ListUsersUseCase extends UseCase<ListUsersRequest, ListUsersResponse> {
-  constructor(private readonly userRepository: IUserRepository) {
+  constructor(@Inject(USER_REPOSITORY) private readonly userRepository: IUserRepository) {
     super();
   }
 
   async execute(request: ListUsersRequest): Promise<ListUsersResponse> {
     const limit = request.limit || 20;
 
-    let users = [];
+    const result = request.search
+      ? await this.userRepository.findBySearchTerm(request.search, limit, request.cursor)
+      : await this.userRepository.findPaginated(limit, request.cursor);
 
-    if (request.search) {
-      users = await this.userRepository.findBySearchTerm(request.search);
-    } else {
-      users = await this.userRepository.findAll();
-    }
-
-    // Apply cursor-based pagination
-    let filteredUsers = users;
-    if (request.cursor) {
-      const cursorIndex = users.findIndex((u) => u.id === request.cursor);
-      if (cursorIndex !== -1) {
-        filteredUsers = users.slice(cursorIndex + 1);
-      }
-    }
-
-    // Check if there are more results
-    const hasMore = filteredUsers.length > limit;
-
-    // Take only the requested limit
-    const paginatedUsers = hasMore ? filteredUsers.slice(0, limit) : filteredUsers;
-
-    const userItems = paginatedUsers.map((user) => {
+    const userItems = result.items.map((user) => {
       const primitives = user.toPrimitives();
       return new ListUserItem(
         primitives.id,
@@ -90,9 +71,8 @@ export class ListUsersUseCase extends UseCase<ListUsersRequest, ListUsersRespons
       );
     });
 
-    // Generate next cursor
-    const nextCursor = hasMore && userItems.length > 0 ? userItems[userItems.length - 1].id : null;
+    const nextCursor = result.hasMore && userItems.length > 0 ? userItems[userItems.length - 1].id : null;
 
-    return new ListUsersResponse(userItems, nextCursor, hasMore);
+    return new ListUsersResponse(userItems, nextCursor, result.hasMore);
   }
 }

--- a/src/user/domain/repositories/user-repository.interface.ts
+++ b/src/user/domain/repositories/user-repository.interface.ts
@@ -1,23 +1,16 @@
 import { IRepository } from '../../../shared/domain/repositories/repository.interface';
 import { User } from '../entities/user.entity';
 
-/**
- * User Repository Interface (for User Module)
- * Extends the generic IRepository with User-specific query methods
- */
+export const USER_REPOSITORY = 'IUserRepository';
+
+export interface PaginatedResult<T> {
+  items: T[];
+  hasMore: boolean;
+}
+
 export interface IUserRepository extends IRepository<User> {
-  /**
-   * Find a user by email
-   */
   findByEmail(email: string): Promise<User | null>;
-
-  /**
-   * Find users by search term (matches first name, last name, or email)
-   */
-  findBySearchTerm(searchTerm: string): Promise<User[]>;
-
-  /**
-   * Find all active users
-   */
+  findBySearchTerm(searchTerm: string, limit: number, afterId?: string): Promise<PaginatedResult<User>>;
   findAllActive(): Promise<User[]>;
+  findPaginated(limit: number, afterId?: string): Promise<PaginatedResult<User>>;
 }

--- a/src/user/infrastructure/repositories/user-repository.impl.ts
+++ b/src/user/infrastructure/repositories/user-repository.impl.ts
@@ -1,17 +1,12 @@
 import { Injectable } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository, ILike } from 'typeorm';
-import { IUserRepository } from '../../domain/repositories/user-repository.interface';
+import { Repository } from 'typeorm';
+import { IUserRepository, PaginatedResult } from '../../domain/repositories/user-repository.interface';
 import { User } from '../../domain/entities/user.entity';
 import { UserPersistenceEntity } from '../persistence/user-persistence.entity';
 import { UserMapper } from '../../application/mappers/user.mapper';
 import { EncryptionService } from '../../../common/encryption.service';
 
-/**
- * User Repository Implementation (for User Module)
- * Implements the IUserRepository interface using TypeORM
- * Handles all database operations for User entities in the user module context
- */
 @Injectable()
 export class UserRepositoryImpl implements IUserRepository {
   constructor(
@@ -29,43 +24,58 @@ export class UserRepositoryImpl implements IUserRepository {
 
   async findById(id: string): Promise<User | null> {
     const entity = await this.typeOrmRepository.findOne({ where: { id } });
-    if (!entity) {
-      return null;
-    }
-    return this.userMapper.toDomain(entity);
+    return entity ? this.userMapper.toDomain(entity) : null;
   }
 
   async findByEmail(email: string): Promise<User | null> {
     const emailHash = this.encryptionService.hash(email.toLowerCase());
     const entity = await this.typeOrmRepository.findOne({ where: { emailHash } as any });
-    if (!entity) {
-      return null;
-    }
-    return this.userMapper.toDomain(entity);
+    return entity ? this.userMapper.toDomain(entity) : null;
   }
 
   async findAll(): Promise<User[]> {
-    const entities = await this.typeOrmRepository.find();
-    return entities.map((entity) => this.userMapper.toDomain(entity));
+    const entities = await this.typeOrmRepository.find({ take: 1000 });
+    return entities.map((e) => this.userMapper.toDomain(e));
   }
 
-  async findBySearchTerm(searchTerm: string): Promise<User[]> {
-    // Note: ILike on encrypted fields (firstName, lastName, email) won't work.
-    // For exact match on email, we can use emailHash.
+  async findPaginated(limit: number, afterId?: string): Promise<PaginatedResult<User>> {
+    const qb = this.typeOrmRepository
+      .createQueryBuilder('user')
+      .orderBy('user.id', 'ASC')
+      .take(limit + 1);
+
+    if (afterId) {
+      qb.where('user.id > :afterId', { afterId });
+    }
+
+    const entities = await qb.getMany();
+    const hasMore = entities.length > limit;
+    const items = entities.slice(0, limit).map((e) => this.userMapper.toDomain(e));
+    return { items, hasMore };
+  }
+
+  async findBySearchTerm(searchTerm: string, limit: number, afterId?: string): Promise<PaginatedResult<User>> {
+    // Partial search on encrypted fields isn't possible; match on emailHash only.
     const emailHash = this.encryptionService.hash(searchTerm.toLowerCase());
-    const entities = await this.typeOrmRepository.find({
-      where: [
-        { emailHash } as any,
-        // Partial search on name is disabled for now due to encryption at rest.
-        // Ideally, these should be indexed in ElasticSearch if partial search is required.
-      ],
-    });
-    return entities.map((entity) => this.userMapper.toDomain(entity));
+    const qb = this.typeOrmRepository
+      .createQueryBuilder('user')
+      .where('user.emailHash = :emailHash', { emailHash })
+      .orderBy('user.id', 'ASC')
+      .take(limit + 1);
+
+    if (afterId) {
+      qb.andWhere('user.id > :afterId', { afterId });
+    }
+
+    const entities = await qb.getMany();
+    const hasMore = entities.length > limit;
+    const items = entities.slice(0, limit).map((e) => this.userMapper.toDomain(e));
+    return { items, hasMore };
   }
 
   async findAllActive(): Promise<User[]> {
     const entities = await this.typeOrmRepository.find({ where: { isActive: true } });
-    return entities.map((entity) => this.userMapper.toDomain(entity));
+    return entities.map((e) => this.userMapper.toDomain(e));
   }
 
   async delete(id: string): Promise<boolean> {

--- a/src/user/user.module.ts
+++ b/src/user/user.module.ts
@@ -4,11 +4,23 @@ import { UserService } from './user.service';
 import { UserController } from './user.controller';
 import { User } from './entities/user.entity';
 import { UserProfile } from './entities/user-profile.entity';
+import { UserPersistenceEntity } from './infrastructure/persistence/user-persistence.entity';
+import { UserRepositoryImpl } from './infrastructure/repositories/user-repository.impl';
+import { UserMapper } from './application/mappers/user.mapper';
+import { ListUsersUseCase } from './application/use-cases/list-users.use-case';
+import { GetUserUseCase } from './application/use-cases/get-user.use-case';
+import { USER_REPOSITORY } from './domain/repositories/user-repository.interface';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([User, UserProfile])],
+  imports: [TypeOrmModule.forFeature([User, UserProfile, UserPersistenceEntity])],
   controllers: [UserController],
-  providers: [UserService],
+  providers: [
+    UserService,
+    UserMapper,
+    { provide: USER_REPOSITORY, useClass: UserRepositoryImpl },
+    ListUsersUseCase,
+    GetUserUseCase,
+  ],
   exports: [UserService],
 })
 export class UserModule {}

--- a/test/concurrent-load.spec.ts
+++ b/test/concurrent-load.spec.ts
@@ -1,0 +1,343 @@
+/**
+ * Concurrent Load Tests
+ * Simulates 100+ users performing simultaneous operations to verify
+ * the system handles concurrency without race conditions or data corruption.
+ */
+
+import { Test, TestingModule } from '@nestjs/testing';
+import { INestApplication, ValidationPipe } from '@nestjs/common';
+import * as http from 'http';
+import request from 'supertest';
+
+import { AuthController } from '../src/auth/controllers/auth.controller';
+import { CourseController } from '../src/course/course.controller';
+import { UserController } from '../src/user/user.controller';
+import { AuthService } from '../src/auth/services/auth.service';
+import { CourseService } from '../src/course/course.service';
+import { UserService } from '../src/user/user.service';
+import { PasswordStrengthService } from '../src/auth/services/password-strength.service';
+import { CookieTokenService } from '../src/auth/services/cookie-token.service';
+import { RateLimiterService } from '../src/auth/guards/rate-limiter.service';
+import { ListUsersUseCase } from '../src/user/application/use-cases/list-users.use-case';
+import { GetUserUseCase } from '../src/user/application/use-cases/get-user.use-case';
+import { ListCoursesUseCase } from '../src/course/application/use-cases/list-courses.use-case';
+import { GetCourseUseCase } from '../src/course/application/use-cases/get-course.use-case';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function makeUser(i: number) {
+  return {
+    id: `user-${i}`,
+    email: `user${i}@test.com`,
+    firstName: `First${i}`,
+    lastName: `Last${i}`,
+    isActive: true,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+function makeCourse(i: number) {
+  return {
+    id: `course-${i}`,
+    title: `Course ${i}`,
+    description: `Description ${i}`,
+    category: i % 2 === 0 ? 'blockchain' : 'defi',
+    difficulty: i % 3 === 0 ? 'beginner' : 'intermediate',
+    isActive: true,
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+  };
+}
+
+/** Run requests in batches to avoid overwhelming the test HTTP server */
+async function fireBatched(
+  reqs: (() => Promise<request.Response>)[],
+  batchSize = 25,
+): Promise<{ responses: request.Response[]; durationMs: number }> {
+  const start = Date.now();
+  const responses: request.Response[] = [];
+
+  for (let i = 0; i < reqs.length; i += batchSize) {
+    const batch = reqs.slice(i, i + batchSize);
+    const batchResults = await Promise.all(batch.map((fn) => fn()));
+    responses.push(...batchResults);
+  }
+
+  return { responses, durationMs: Date.now() - start };
+}
+
+// ─── App factory ────────────────────────────────────────────────────────────
+
+async function buildApp(): Promise<INestApplication> {
+  const users = Array.from({ length: 120 }, (_, i) => makeUser(i));
+  const courses = Array.from({ length: 120 }, (_, i) => makeCourse(i));
+
+  const mockRateLimiter = {
+    isAllowed: jest.fn().mockReturnValue({ allowed: true, remaining: 999, resetTime: Date.now() + 60000 }),
+    getStatus: jest.fn(),
+    reset: jest.fn(),
+    resetAll: jest.fn(),
+    cleanup: jest.fn(),
+  };
+
+  const mockAuthService = {
+    login: jest.fn().mockResolvedValue({ message: 'Login successful', user: makeUser(0) }),
+    register: jest.fn().mockResolvedValue({ message: 'Registration successful', user: makeUser(0) }),
+    forgotPassword: jest.fn().mockResolvedValue({ message: 'If email exists, a reset link has been sent' }),
+  };
+
+  const mockCourseService = {
+    findAll: jest.fn().mockResolvedValue(courses.slice(0, 20)),
+    findOne: jest.fn().mockImplementation((id: string) =>
+      Promise.resolve(courses.find((c) => c.id === id) ?? null),
+    ),
+  };
+
+  const mockUserService = {
+    findAll: jest.fn().mockResolvedValue(users.slice(0, 20)),
+    findOne: jest.fn().mockImplementation((id: string) =>
+      Promise.resolve(users.find((u) => u.id === id) ?? null),
+    ),
+  };
+
+  const mockListUsersUseCase = {
+    execute: jest.fn().mockResolvedValue({ users: users.slice(0, 20), nextCursor: null, hasMore: false }),
+  };
+
+  const mockGetUserUseCase = {
+    execute: jest.fn().mockImplementation(({ userId }: { userId: string }) =>
+      Promise.resolve(users.find((u) => u.id === userId) ?? null),
+    ),
+  };
+
+  const mockListCoursesUseCase = {
+    execute: jest.fn().mockResolvedValue({ courses: courses.slice(0, 20), nextCursor: null, hasMore: false }),
+  };
+
+  const mockGetCourseUseCase = {
+    execute: jest.fn().mockImplementation(({ courseId }: { courseId: string }) =>
+      Promise.resolve(courses.find((c) => c.id === courseId) ?? null),
+    ),
+  };
+
+  const module: TestingModule = await Test.createTestingModule({
+    controllers: [AuthController, CourseController, UserController],
+    providers: [
+      { provide: AuthService, useValue: mockAuthService },
+      { provide: CourseService, useValue: mockCourseService },
+      { provide: UserService, useValue: mockUserService },
+      { provide: ListUsersUseCase, useValue: mockListUsersUseCase },
+      { provide: GetUserUseCase, useValue: mockGetUserUseCase },
+      { provide: ListCoursesUseCase, useValue: mockListCoursesUseCase },
+      { provide: GetCourseUseCase, useValue: mockGetCourseUseCase },
+      { provide: RateLimiterService, useValue: mockRateLimiter },
+      PasswordStrengthService,
+      CookieTokenService,
+    ],
+  }).compile();
+
+  const app = module.createNestApplication();
+  app.useGlobalPipes(new ValidationPipe({ whitelist: true, transform: true }));
+  await app.init();
+
+  // Raise the connection limit so 100 concurrent requests don't get ECONNRESET
+  const httpServer = app.getHttpServer() as http.Server;
+  httpServer.maxConnections = 500;
+
+  return app;
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('Concurrent Load – 100+ users', () => {
+  let app: INestApplication;
+  let server: any;
+
+  beforeAll(async () => {
+    app = await buildApp();
+    server = app.getHttpServer();
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  // ── Read endpoints ────────────────────────────────────────────────────────
+
+  it('handles 100 concurrent GET /courses requests', async () => {
+    const reqs = Array.from({ length: 100 }, () => () => request(server).get('/courses'));
+
+    const { responses, durationMs } = await fireBatched(reqs);
+
+    expect(responses.every((r) => r.status === 200)).toBe(true);
+    expect(durationMs).toBeLessThan(10000);
+  }, 15000);
+
+  it('handles 100 concurrent GET /users requests', async () => {
+    const reqs = Array.from({ length: 100 }, () => () => request(server).get('/users'));
+
+    const { responses, durationMs } = await fireBatched(reqs);
+
+    expect(responses.every((r) => r.status === 200)).toBe(true);
+    expect(durationMs).toBeLessThan(10000);
+  }, 15000);
+
+  it('handles 120 concurrent mixed reads without any 5xx errors', async () => {
+    const courseIds = Array.from({ length: 10 }, (_, i) => `course-${i}`);
+    const userIds = Array.from({ length: 10 }, (_, i) => `user-${i}`);
+
+    const reqs = [
+      ...Array.from({ length: 40 }, () => () => request(server).get('/courses')),
+      ...Array.from({ length: 40 }, () => () => request(server).get('/users')),
+      ...Array.from({ length: 20 }, (_, i) => () =>
+        request(server).get(`/courses/${courseIds[i % courseIds.length]}`),
+      ),
+      ...Array.from({ length: 20 }, (_, i) => () =>
+        request(server).get(`/users/${userIds[i % userIds.length]}`),
+      ),
+    ];
+
+    const { responses } = await fireBatched(reqs);
+
+    expect(responses.filter((r) => r.status >= 500).length).toBe(0);
+  }, 20000);
+
+  // ── Write endpoints ───────────────────────────────────────────────────────
+
+  it('handles 100 concurrent POST /auth/login requests', async () => {
+    const reqs = Array.from({ length: 100 }, (_, i) => () =>
+      request(server)
+        .post('/auth/login')
+        .send({ email: `user${i}@test.com`, password: 'Password123!' }),
+    );
+
+    const { responses, durationMs } = await fireBatched(reqs);
+
+    expect(responses.every((r) => r.status === 200)).toBe(true);
+    expect(durationMs).toBeLessThan(10000);
+  }, 15000);
+
+  it('handles 100 concurrent POST /auth/register requests', async () => {
+    const reqs = Array.from({ length: 100 }, (_, i) => () =>
+      request(server)
+        .post('/auth/register')
+        .send({
+          email: `newuser${i}@test.com`,
+          password: 'Password123!',
+          passwordConfirm: 'Password123!',
+          firstName: `First${i}`,
+          lastName: `Last${i}`,
+        }),
+    );
+
+    const { responses } = await fireBatched(reqs);
+
+    expect(responses.every((r) => r.status === 201)).toBe(true);
+  }, 15000);
+
+  // ── Race condition: rate limiter state ────────────────────────────────────
+
+  it('rate limiter counts are consistent under concurrent access', () => {
+    const limiter = new RateLimiterService();
+
+    const results = Array.from({ length: 50 }, () =>
+      limiter.isAllowed('test:concurrent', 10, 60_000),
+    );
+
+    expect(results.filter((r) => r.allowed).length).toBe(10);
+    expect(results.filter((r) => !r.allowed).length).toBe(40);
+  });
+
+  it('rate limiter remaining count decrements correctly under load', () => {
+    const limiter = new RateLimiterService();
+    const max = 20;
+
+    const results = Array.from({ length: max }, () =>
+      limiter.isAllowed('test:decrement', max, 60_000),
+    );
+
+    const allowed = results.filter((r) => r.allowed);
+    expect(allowed.length).toBe(max);
+
+    for (let i = 0; i < allowed.length - 1; i++) {
+      expect(allowed[i].remaining).toBeGreaterThan(allowed[i + 1].remaining);
+    }
+  });
+
+  // ── No 5xx under concurrent password checks ───────────────────────────────
+
+  it('no 5xx errors under 100 concurrent password-strength checks', async () => {
+    const passwords = ['weak', 'Password123!', 'short', 'VeryStr0ng!Pass#2024', ''];
+
+    const reqs = Array.from({ length: 100 }, (_, i) => () =>
+      request(server)
+        .post('/auth/check-password-strength')
+        .send({ password: passwords[i % passwords.length] }),
+    );
+
+    const { responses } = await fireBatched(reqs);
+
+    expect(responses.filter((r) => r.status >= 500).length).toBe(0);
+  }, 15000);
+
+  // ── Response time SLA ─────────────────────────────────────────────────────
+
+  it('p95 response time under 1000ms for 100 concurrent course reads', async () => {
+    const times: number[] = [];
+
+    const reqs = Array.from({ length: 100 }, () => async () => {
+      const start = Date.now();
+      const res = await request(server).get('/courses');
+      times.push(Date.now() - start);
+      return res;
+    });
+
+    await fireBatched(reqs);
+
+    times.sort((a, b) => a - b);
+    const p95 = times[Math.floor(times.length * 0.95)];
+    expect(p95).toBeLessThan(1000);
+  }, 15000);
+
+  it('p95 response time under 1000ms for 100 concurrent user reads', async () => {
+    const times: number[] = [];
+
+    const reqs = Array.from({ length: 100 }, () => async () => {
+      const start = Date.now();
+      const res = await request(server).get('/users');
+      times.push(Date.now() - start);
+      return res;
+    });
+
+    await fireBatched(reqs);
+
+    times.sort((a, b) => a - b);
+    const p95 = times[Math.floor(times.length * 0.95)];
+    expect(p95).toBeLessThan(1000);
+  }, 15000);
+
+  // ── Sustained load ────────────────────────────────────────────────────────
+
+  it('sustains 100 users over 3 waves without degradation', async () => {
+    const wave = () =>
+      fireBatched([
+        ...Array.from({ length: 34 }, () => () => request(server).get('/courses')),
+        ...Array.from({ length: 33 }, () => () => request(server).get('/users')),
+        ...Array.from({ length: 33 }, () => () =>
+          request(server).post('/auth/check-password-strength').send({ password: 'Test123!' }),
+        ),
+      ]);
+
+    const waveTimes: number[] = [];
+
+    for (let i = 0; i < 3; i++) {
+      const { responses, durationMs } = await wave();
+      waveTimes.push(durationMs);
+      expect(responses.filter((r) => r.status >= 500).length).toBe(0);
+    }
+
+    // Third wave should not be dramatically slower than the first
+    expect(waveTimes[2]).toBeLessThan(waveTimes[0] * 3);
+  }, 60000);
+});


### PR DESCRIPTION
- Add findPaginated(limit, afterId) to user and course repositories using WHERE id > :afterId LIMIT n+1 keyset pattern
- Update findBySearchTerm, findByCategory, findByDifficulty, findByCategoryAndDifficulty to accept limit/afterId params
- Rewrite ListUsersUseCase and ListCoursesUseCase to delegate pagination to the repository instead of slicing in memory
- Add USER_REPOSITORY and COURSE_REPOSITORY string tokens for NestJS DI (interfaces cannot be used as runtime tokens)
- Wire use cases, repositories, mappers, and persistence entities into UserModule and CourseModule providers
- Add safety take(1000) cap on raw findAll() calls
- Remove unreachable throw in auth.service.ts resetPassword

closes #783